### PR TITLE
Added some infos on how to build the documentation.

### DIFF
--- a/COMPILE
+++ b/COMPILE
@@ -77,3 +77,11 @@ for 64 bits systems
 VISUAL C++ USERS
 .........................................................
 Open squirrel.dsw from the root project directory and build(dho!)
+
+
+DOCUMENTATION GENERATION
+.........................................................
+To be able to compile the documentation, make sure that you have Python
+installed and the packages sphinx and sphinx_rtd_theme. Browse into doc/
+and use either the Makefile for GCC-based platforms or make.bat for
+Windows platforms.

--- a/COMPILE
+++ b/COMPILE
@@ -78,7 +78,6 @@ VISUAL C++ USERS
 .........................................................
 Open squirrel.dsw from the root project directory and build(dho!)
 
-
 DOCUMENTATION GENERATION
 .........................................................
 To be able to compile the documentation, make sure that you have Python

--- a/doc/source/reference/index.rst
+++ b/doc/source/reference/index.rst
@@ -4,7 +4,7 @@
   Squirrel 3.1 Reference Manual
 #################################
 
-Copyrigth (c) 2003-2016 Alberto Demichelis
+Copyright (c) 2003-2016 Alberto Demichelis
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/doc/source/stdlib/index.rst
+++ b/doc/source/stdlib/index.rst
@@ -4,7 +4,7 @@
   Squirrel Standard Library 3.1
 #################################
 
-Copyrigth (c) 2003-2016 Alberto Demichelis
+Copyright (c) 2003-2016 Alberto Demichelis
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Looks like I had to install two packages to be able to compile the doc by myself. I added some indications about such requirements so the programmer/user won't be surprised by the lack of dependencies at compile time. 

Edit : Also fixing some mistypings or mistakes in the documentation.