### PR TITLE
fix parsing of incomplete regexp escape sequence

### DIFF
--- a/doc/source/stdlib/stdstringlib.rst
+++ b/doc/source/stdlib/stdstringlib.rst
@@ -69,8 +69,8 @@ The regexp class
 
 .. js:class:: regexp(pattern)
 
-    The regexp object represent a precompiled regular expression pattern. The object is created
-    trough `regexp(patern)`.
+    The regexp object represents a precompiled regular expression pattern. The object is created
+    through `regexp(pattern)`.
 
 
 +---------------------+--------------------------------------+

--- a/sqstdlib/sqstdrex.cpp
+++ b/sqstdlib/sqstdrex.cpp
@@ -153,6 +153,9 @@ static SQInteger sqstd_rex_charnode(SQRex *exp,SQBool isclass)
                      exp->_nodes[node].right = ce;
                      return node;
                 }
+            case 0:
+                sqstd_rex_error(exp,_SC("letter expected for argument of escape sequence"));
+                break;                
             case 'b':
             case 'B':
                 if(!isclass) {


### PR DESCRIPTION
Currently, a regexp like "\" will result in a nondeterministic malfunction as it attempts to continue parsing beyond the null terminator. This patch fixes that.