### PR TITLE
Tidy sqvm.h and docs fixes

### DIFF
--- a/doc/source/reference/api/object_manipulation.rst
+++ b/doc/source/reference/api/object_manipulation.rst
@@ -135,7 +135,7 @@ Clones the table, array or class instance at the position idx, clones it and pus
     :returns: a SQRESULT
     :remarks: invoke the _newslot metamethod in the table delegate. it only works on tables. [this function is deperecated since version 2.0.5 use sq_newslot() instead]
 
-pops a key and a value from the stack and performs a set operation on the table or class that is at position idx in the stack, if the slot does not exits it will be created.
+pops a key and a value from the stack and performs a set operation on the table or class that is at position idx in the stack; if the slot does not exist, it will be created.
 
 
 
@@ -151,7 +151,7 @@ pops a key and a value from the stack and performs a set operation on the table 
     :returns: a SQRESULT
     :remarks: invoke the _delslot metamethod in the table delegate. it only works on tables.
 
-pops a key from the stack and delete the slot indexed by it from the table at position idx in the stack, if the slot does not exits nothing happens.
+pops a key from the stack and delete the slot indexed by it from the table at position idx in the stack; if the slot does not exist, nothing happens.
 
 
 
@@ -164,7 +164,7 @@ pops a key from the stack and delete the slot indexed by it from the table at po
     :param HSQUIRRELVM v: the target VM
     :param SQInteger idx: index of the target object in the stack
     :returns: a SQRESULT
-    :remarks: this call will invokes the delegation system like a normal dereference it only works on tables, arrays and userdata. If the function fails, nothing will be pushed in the stack.
+    :remarks: this call will invokes the delegation system like a normal dereference it only works on tables, arrays and userdata; if the function fails, nothing will be pushed in the stack.
 
 pops a key from the stack and performs a get operation on the object at the position idx in the stack; and pushes the result in the stack.
 
@@ -283,7 +283,7 @@ Determines if an object is an instance of a certain class. Expects an instance a
     :returns: a SQRESULT
     :remarks: Invokes the _newmember metamethod in the class. it only works on classes.
 
-pops a key, a value and an object (which will be set as attribute of the member) from the stack and performs a new slot operation on the class that is at position idx in the stack; if the slot does not exits it will be created.
+pops a key, a value and an object (which will be set as attribute of the member) from the stack and performs a new slot operation on the class that is at position idx in the stack; if the slot does not exist, it will be created.
 
 
 
@@ -299,7 +299,7 @@ pops a key, a value and an object (which will be set as attribute of the member)
     :returns: a SQRESULT
     :remarks: Invokes the _newslot metamethod in the table delegate. it only works on tables and classes.
 
-pops a key and a value from the stack and performs a set operation on the table or class that is at position idx in the stack, if the slot does not exits it will be created.
+pops a key and a value from the stack and performs a set operation on the table or class that is at position idx in the stack, if the slot does not exist it will be created.
 
 
 
@@ -328,7 +328,7 @@ Pushes in the stack the next key and value of an array, table, or class slot. To
     :param SQBool pushval: if this param is true the function will push the value of the deleted slot.
     :returns: a SQRESULT
 
-Deletes a slot from a table without employing the _delslot metamethod. Pops a key from the stack and delete the slot indexed by it from the table at position idx in the stack, if the slot does not exits nothing happens.
+Deletes a slot from a table without employing the _delslot metamethod. Pops a key from the stack and delete the slot indexed by it from the table at position idx in the stack; if the slot does not exist nothing happens.
 
 
 
@@ -359,7 +359,7 @@ pops a key from the stack and performs a get operation on the object at position
     :returns: a SQRESULT
     :remarks: it only works on classes.
 
-pops a key, a value and an object(that will be set as attribute of the member) from the stack and performs a new slot operation on the class that is at position idx in the stack, if the slot does not exits it will be created.
+pops a key, a value and an object(that will be set as attribute of the member) from the stack and performs a new slot operation on the class that is at position idx in the stack; if the slot does not exist it will be created.
 
 
 

--- a/doc/source/reference/language/metamethods.rst
+++ b/doc/source/reference/language/metamethods.rst
@@ -63,7 +63,7 @@ _set
     _set(idx,val)
 
 invoked when the index idx is not present in the object or in its delegate chain.
-``_set`` must 'throw null' to notify that a key wasn't found but the there were not runtime errors(clean failure).
+``_set`` must 'throw null' to notify that a key wasn't found but the there were not runtime errors (clean failure).
 This allows the program to differentiate between a runtime error and a 'index not found'.
 
 ^^^^^
@@ -75,7 +75,7 @@ _get
     _get(idx)
 
 invoked when the index idx is not present in the object or in its delegate chain.
-_get must 'throw null' to notify that a key wasn't found but the there were not runtime errors(clean failure).
+_get must 'throw null' to notify that a key wasn't found but the there were not runtime errors (clean failure).
 This allows the program to differentiate between a runtime error and a 'index not found'.
 
 ^^^^^^^^^
@@ -165,16 +165,16 @@ _unm
 the unary minus operator
 
 ^^^^^^^^^^^^^^^^^^^^^^^^
-_tyoeof
+_typeof
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
 ::
 
-    _tyoeof()
+    _typeof()
 
-invoked by the typeof operator on tables, userdata and class instances
+invoked by the typeof operator on tables, userdata, and class instances.
 
-returns the type of ``this`` as string
+Returns the type of ``this`` as string
 
 ^^^^^^^^^^^^^^^^^^^^^^^^
 _cmp
@@ -228,7 +228,7 @@ _nexti
 
 invoked when a userdata or class instance is iterated by a foreach loop
 
-if previdx==null it means that it is the first iteration.
+If previdx==null it means that it is the first iteration.
 The function has to return the index of the 'next' value.
 
 ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -239,10 +239,10 @@ _tostring
 
     _tostring(previdx)
 
-invoked when during string conacatenation or when the ``print`` function prints a table, instance, or userdata.
-The method is also invoked by the sq_tostring() api
+invoked when during string concatenation or when the ``print`` function prints a table, instance, or userdata.
+The method is also invoked by the sq_tostring() API
 
-must return a string representation of the object.
+Must return a string representation of the object.
 
 ^^^^^^^^^^^^^^^^^^^^^^^^
 _inherited
@@ -252,10 +252,10 @@ _inherited
 
     _inherited(attributes)
 
-invoked when a class object inherits from the class implementing ``_inherited``
-the ``this`` contains the new class.
+invoked when a class object inherits from the class implementing ``_inherited``.
+The ``this`` contains the new class.
 
-return value is ignored.
+Return value is ignored.
 
 ^^^^^^^^^^^^^^^^^^^^^^^^
 _newmember
@@ -265,6 +265,6 @@ _newmember
 
     _newmember(index,value,attributes,isstatic)
 
-invoked for each member declared in a class body(at declaration time).
+invoked for each member declared in a class body (at declaration time).
 
-if the function is implemented, members will not be added to the class.
+If the function is implemented, members will not be added to the class.

--- a/squirrel/sqvm.cpp
+++ b/squirrel/sqvm.cpp
@@ -15,6 +15,8 @@
 #include "sqclass.h"
 
 #define TOP() (_stack._vals[_top-1])
+#define TARGET _stack._vals[_stackbase+arg0]
+#define STK(a) _stack._vals[_stackbase+(a)]
 
 bool SQVM::BW_OP(SQUnsignedInteger op,SQObjectPtr &trg,const SQObjectPtr &o1,const SQObjectPtr &o2)
 {

--- a/squirrel/sqvm.h
+++ b/squirrel/sqvm.h
@@ -28,9 +28,6 @@ struct SQExceptionTrap{
 
 #define _INLINE
 
-#define STK(a) _stack._vals[_stackbase+(a)]
-#define TARGET _stack._vals[_stackbase+arg0]
-
 typedef sqvector<SQExceptionTrap> ExceptionsTraps;
 
 struct SQVM : public CHAINABLE_OBJ


### PR DESCRIPTION
Just a small thing.

sqvm.cpp already had `#define TOP() (_stack._vals[_top-1])`
Shouldnt it have 
```
#define TARGET _stack._vals[_stackbase+arg0]
#define STK(a) _stack._vals[_stackbase+(a)]
```
also, instead of sqvm.h? Nothing else uses those and the names were colliding with something else I had.

