### PR TITLE
feature: add SQPString and sq_getpstring()

### DIFF
--- a/doc/source/reference/api/object_creation_and_handling.rst
+++ b/doc/source/reference/api/object_creation_and_handling.rst
@@ -243,6 +243,21 @@ gets a pointer to the string at the idx position in the stack.
 
 
 
+.. _sq_getstringandsize:
+
+.. c:function:: SQRESULT sq_getstringandsize(HSQUIRRELVM v, SQInteger idx, const SQChar ** c, SQInteger* size)
+
+    :param HSQUIRRELVM v: the target VM
+    :param SQInteger idx: an index in the stack
+    :param const SQChar ** c: a pointer to the pointer that will point to the string
+    :param SQInteger * size: a pointer to a SQInteger which will receive the size of the string
+    :returns: a SQRESULT
+
+gets a pointer to the string at the idx position in the stack; additionally retrieves its size.
+
+
+
+
 .. _sq_getthread:
 
 .. c:function:: SQRESULT sq_getthread(HSQUIRRELVM v, SQInteger idx, HSQUIRRELVM* v)

--- a/doc/source/reference/embedding/the_stack.rst
+++ b/doc/source/reference/embedding/the_stack.rst
@@ -92,6 +92,7 @@ the result can be one of the following values: ::
 The following functions convert a squirrel value in the stack to a C value::
 
     SQRESULT sq_getstring(HSQUIRRELVM v,SQInteger idx,const SQChar **c);
+    SQRESULT sq_getstringandsize(HSQUIRRELVM v,SQInteger idx,const SQChar **c,SQInteger size);
     SQRESULT sq_getinteger(HSQUIRRELVM v,SQInteger idx,SQInteger *i);
     SQRESULT sq_getfloat(HSQUIRRELVM v,SQInteger idx,SQFloat *f);
     SQRESULT sq_getuserpointer(HSQUIRRELVM v,SQInteger idx,SQUserPointer *p);

--- a/include/squirrel.h
+++ b/include/squirrel.h
@@ -156,6 +156,12 @@ typedef struct tagSQObject
     SQObjectValue _unVal;
 }SQObject;
 
+typedef struct tagSQPString
+{
+    SQInteger len;
+    SQChar* str;
+} SQPString;
+
 typedef struct  tagSQMemberHandle{
     SQBool _static;
     SQInteger _index;
@@ -259,6 +265,7 @@ SQUIRREL_API SQBool sq_instanceof(HSQUIRRELVM v);
 SQUIRREL_API SQRESULT sq_tostring(HSQUIRRELVM v,SQInteger idx);
 SQUIRREL_API void sq_tobool(HSQUIRRELVM v, SQInteger idx, SQBool *b);
 SQUIRREL_API SQRESULT sq_getstring(HSQUIRRELVM v,SQInteger idx,const SQChar **c);
+SQUIRREL_API SQRESULT sq_getpstring(HSQUIRRELVM v,SQInteger idx,SQPString *pstr);
 SQUIRREL_API SQRESULT sq_getinteger(HSQUIRRELVM v,SQInteger idx,SQInteger *i);
 SQUIRREL_API SQRESULT sq_getfloat(HSQUIRRELVM v,SQInteger idx,SQFloat *f);
 SQUIRREL_API SQRESULT sq_getbool(HSQUIRRELVM v,SQInteger idx,SQBool *b);

--- a/include/squirrel.h
+++ b/include/squirrel.h
@@ -156,12 +156,6 @@ typedef struct tagSQObject
     SQObjectValue _unVal;
 }SQObject;
 
-typedef struct tagSQPString
-{
-    SQInteger len;
-    SQChar* str;
-} SQPString;
-
 typedef struct  tagSQMemberHandle{
     SQBool _static;
     SQInteger _index;
@@ -264,8 +258,8 @@ SQUIRREL_API SQRESULT sq_getbase(HSQUIRRELVM v,SQInteger idx);
 SQUIRREL_API SQBool sq_instanceof(HSQUIRRELVM v);
 SQUIRREL_API SQRESULT sq_tostring(HSQUIRRELVM v,SQInteger idx);
 SQUIRREL_API void sq_tobool(HSQUIRRELVM v, SQInteger idx, SQBool *b);
+SQUIRREL_API SQRESULT sq_getstringandsize(HSQUIRRELVM v,SQInteger idx,const SQChar **c,SQInteger *size);
 SQUIRREL_API SQRESULT sq_getstring(HSQUIRRELVM v,SQInteger idx,const SQChar **c);
-SQUIRREL_API SQRESULT sq_getpstring(HSQUIRRELVM v,SQInteger idx,SQPString *pstr);
 SQUIRREL_API SQRESULT sq_getinteger(HSQUIRRELVM v,SQInteger idx,SQInteger *i);
 SQUIRREL_API SQRESULT sq_getfloat(HSQUIRRELVM v,SQInteger idx,SQFloat *f);
 SQUIRREL_API SQRESULT sq_getbool(HSQUIRRELVM v,SQInteger idx,SQBool *b);

--- a/squirrel/sqapi.cpp
+++ b/squirrel/sqapi.cpp
@@ -680,12 +680,12 @@ SQRESULT sq_getbool(HSQUIRRELVM v,SQInteger idx,SQBool *b)
     return SQ_ERROR;
 }
 
-SQRESULT sq_getpstring(HSQUIRRELVM v,SQInteger idx,SQPString *pstr)
+SQRESULT sq_getstringandsize(HSQUIRRELVM v,SQInteger idx,const SQChar **c,SQInteger *size)
 {
     SQObjectPtr *o = NULL;
     _GETSAFE_OBJ(v, idx, OT_STRING,o);
-    pstr->len = _stringlen(*o);
-    pstr->str = _stringval(*o);
+    *c = _stringval(*o);
+    *size = _stringlen(*o);
     return SQ_OK;
 }
 

--- a/squirrel/sqapi.cpp
+++ b/squirrel/sqapi.cpp
@@ -680,6 +680,15 @@ SQRESULT sq_getbool(HSQUIRRELVM v,SQInteger idx,SQBool *b)
     return SQ_ERROR;
 }
 
+SQRESULT sq_getpstring(HSQUIRRELVM v,SQInteger idx,SQPString *pstr)
+{
+    SQObjectPtr *o = NULL;
+    _GETSAFE_OBJ(v, idx, OT_STRING,o);
+    pstr->len = _stringlen(*o);
+    pstr->str = _stringval(*o);
+    return SQ_OK;
+}
+
 SQRESULT sq_getstring(HSQUIRRELVM v,SQInteger idx,const SQChar **c)
 {
     SQObjectPtr *o = NULL;


### PR DESCRIPTION
this is an easy way to retrieve strings from the stack along with their size, to avoid useless strlens later. it's named PString to suggest that it's like a pascal-style PSTring, prefixed with the length--that's basically what it is.

It may be of dubious value so I put it in a branch for others to evaluate, but at least it's the kind of thing @mingodad is into also.  I think everyone here could think of about 90 functions to add to the core API and I don't know where it should end, but this one is very small. It just seems a shame to not be able to take advantage of the string length that squirrel already has.

