### PR TITLE
add #include <assert.h> to sqobject.h, since it calls assert()

### DIFF
--- a/squirrel/sqobject.h
+++ b/squirrel/sqobject.h
@@ -3,6 +3,7 @@
 #define _SQOBJECT_H_
 
 #include "squtils.h"
+#include <assert.h>
 
 #ifdef _SQ64
 #define UINT_MINUS_ONE (0xFFFFFFFFFFFFFFFF)


### PR DESCRIPTION
add #include <assert.h> to sqobject.h, since it calls assert():

you may wish to solve this another way, though. sqpcheader.h or somesuch? I'm not really sure what the best solution is. I mean, in general, my policy is, you use it, you include it. But the philosophy of keeping various squirrel files as lightweight as possible is important; I dont fully understand squirrel's method here, so that's why I'm not sure.

Consider this more of a discussion than an actual PR.