### PR TITLE
FIX: no warnings on unused arguments on non-gnu compilers

### DIFF
--- a/include/squirrel.h
+++ b/include/squirrel.h
@@ -396,7 +396,7 @@ SQUIRREL_API void sq_setnativedebughook(HSQUIRRELVM v,SQDEBUGHOOK hook);
 #ifdef __GNUC__
 # define SQ_UNUSED_ARG(x) __attribute__((unused)) x
 #else
-# define SQ_UNUSED_ARG(x) x
+# define SQ_UNUSED_ARG(x)
 #endif
 
 #ifdef __cplusplus

--- a/sq/sq.c
+++ b/sq/sq.c
@@ -52,7 +52,6 @@ void printfunc(HSQUIRRELVM SQ_UNUSED_ARG(v),const SQChar *s,...)
     va_start(vl, s);
     scvprintf(stdout, s, vl);
     va_end(vl);
-    (void)v; /* UNUSED */
 }
 
 void errorfunc(HSQUIRRELVM SQ_UNUSED_ARG(v),const SQChar *s,...)

--- a/squirrel/sqclass.cpp
+++ b/squirrel/sqclass.cpp
@@ -189,7 +189,7 @@ SQInstance::~SQInstance()
     if(_class){ Finalize(); } //if _class is null it was already finalized by the GC
 }
 
-bool SQInstance::GetMetaMethod(SQVM SQ_UNUSED_ARG(*v),SQMetaMethod mm,SQObjectPtr &res)
+bool SQInstance::GetMetaMethod(SQVM* SQ_UNUSED_ARG(v),SQMetaMethod mm,SQObjectPtr &res)
 {
     if(type(_class->_metamethods[mm]) != OT_NULL) {
         res = _class->_metamethods[mm];

--- a/squirrel/sqstate.cpp
+++ b/squirrel/sqstate.cpp
@@ -241,7 +241,7 @@ void SQSharedState::MarkObject(SQObjectPtr &o,SQCollectable **chain)
     }
 }
 
-void SQSharedState::RunMark(SQVM SQ_UNUSED_ARG(*vm),SQCollectable **tchain)
+void SQSharedState::RunMark(SQVM* SQ_UNUSED_ARG(vm),SQCollectable **tchain)
 {
     SQVM *vms = _thread(_root_vm);
 


### PR DESCRIPTION
With this small change non-gnu compilers will not warn on unused function arguments.