### PR TITLE
support sq_getinteger() for bools 

### DIFF
--- a/squirrel/sqapi.cpp
+++ b/squirrel/sqapi.cpp
@@ -657,6 +657,10 @@ SQRESULT sq_getinteger(HSQUIRRELVM v,SQInteger idx,SQInteger *i)
         *i = tointeger(o);
         return SQ_OK;
     }
+    if(sq_isbool(o)) {
+        *i = SQVM::IsFalse(o)?SQFalse:SQTrue;
+        return SQ_OK;
+    }
     return SQ_ERROR;
 }
 


### PR DESCRIPTION
Support sq_getinteger() for bools.
Returns SQFalse or SQTrue in the SQInteger. 
Useful for format("%d",mybool)

Rationale: squirrel seems to apply some logic to type conversion which makes sense to any C-oriented programmer. I think this one falls under that category, and its absence is just an oversight.

Another way to do this might be to classify bool as numeric (and it would be automatically handled by the case above), but that could have wide-ranging consequences. But if that sounds interesting, we can discuss it here. Otherwise just this makes debugging bools much more pleasant.