### PR TITLE
add mechanism for configuring squirrel by optionally #including a file in squirrel.h

### DIFF
--- a/include/squirrel.h
+++ b/include/squirrel.h
@@ -22,6 +22,10 @@ THE SOFTWARE.
 #ifndef _SQUIRREL_H_
 #define _SQUIRREL_H_
 
+#ifdef _SQ_CONFIG_INCLUDE
+#include _SQ_CONFIG_INCLUDE
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/squirrel/sqapi.cpp
+++ b/squirrel/sqapi.cpp
@@ -1243,7 +1243,7 @@ SQRESULT sq_writeclosure(HSQUIRRELVM v,SQWRITEFUNC w,SQUserPointer up)
     _GETSAFE_OBJ(v, -1, OT_CLOSURE,o);
     unsigned short tag = SQ_BYTECODE_STREAM_TAG;
     if(_closure(*o)->_function->_noutervalues)
-        return sq_throwerror(v,_SC("a closure with free valiables bound it cannot be serialized"));
+        return sq_throwerror(v,_SC("a closure with free variables bound cannot be serialized"));
     if(w(up,&tag,2) != 2)
         return sq_throwerror(v,_SC("io error"));
     if(!_closure(*o)->Save(v,up,w))


### PR DESCRIPTION
by #defining _SQ_CONFIG_INCLUDE, that file will be #included early om squirrel.h
This will let you more easily configure how squirrel gets built.

(also fix a typo in an error message)