### PR TITLE
squirrel: sqvm: remove useless assert(0) to fix GCC6 warning

### DIFF
--- a/squirrel/sqvm.cpp
+++ b/squirrel/sqvm.cpp
@@ -1092,7 +1092,6 @@ exception_trap:
         _lasterror = currerror;
         return false;
     }
-    assert(0);
 }
 
 bool SQVM::CreateClassInstance(SQClass *theclass, SQObjectPtr &inst, SQObjectPtr &constructor)


### PR DESCRIPTION
this is the warning:
squirrel/sqvm.cpp: In member function 'bool SQVM::Execute(SQObjectPtr&, SQInteger, SQInteger, SQObjectPtr&, SQBool, SQVM::ExecutionType)':
squirrel/sqvm.cpp:1096:1: error: control reaches end of non-void function [-Werror=return-type]
 }
 ^
cc1plus: all warnings being treated as errors

the assert(0) is useless because there's an unavoidable "return false" above.
this patch is related to the following GCC bug:
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=71943