### PR TITLE
Normalize whitespace.

### DIFF
--- a/README
+++ b/README
@@ -12,7 +12,7 @@ The following compilers have been confirmed to be working:
                    7.1   v
                    8.0
                    9.0
-                  10.0 
+                  10.0
                   12.0  ---
     MinGW gcc 3.2 (mingw special 20020817-1)
     Cygnus gcc 3.2

--- a/doc/make.bat
+++ b/doc/make.bat
@@ -3,48 +3,48 @@
 REM Command file for Sphinx documentation
 
 if "%SPHINXBUILD%" == "" (
-	set SPHINXBUILD=sphinx-build
+    set SPHINXBUILD=sphinx-build
 )
 set BUILDDIR=build
 set ALLSPHINXOPTS=-d %BUILDDIR%/doctrees %SPHINXOPTS% source
 set I18NSPHINXOPTS=%SPHINXOPTS% source
 if NOT "%PAPER%" == "" (
-	set ALLSPHINXOPTS=-D latex_paper_size=%PAPER% %ALLSPHINXOPTS%
-	set I18NSPHINXOPTS=-D latex_paper_size=%PAPER% %I18NSPHINXOPTS%
+    set ALLSPHINXOPTS=-D latex_paper_size=%PAPER% %ALLSPHINXOPTS%
+    set I18NSPHINXOPTS=-D latex_paper_size=%PAPER% %I18NSPHINXOPTS%
 )
 
 if "%1" == "" goto help
 
 if "%1" == "help" (
-	:help
-	echo.Please use `make ^<target^>` where ^<target^> is one of
-	echo.  html       to make standalone HTML files
-	echo.  dirhtml    to make HTML files named index.html in directories
-	echo.  singlehtml to make a single large HTML file
-	echo.  pickle     to make pickle files
-	echo.  json       to make JSON files
-	echo.  htmlhelp   to make HTML files and a HTML help project
-	echo.  qthelp     to make HTML files and a qthelp project
-	echo.  devhelp    to make HTML files and a Devhelp project
-	echo.  epub       to make an epub
-	echo.  latex      to make LaTeX files, you can set PAPER=a4 or PAPER=letter
-	echo.  text       to make text files
-	echo.  man        to make manual pages
-	echo.  texinfo    to make Texinfo files
-	echo.  gettext    to make PO message catalogs
-	echo.  changes    to make an overview over all changed/added/deprecated items
-	echo.  xml        to make Docutils-native XML files
-	echo.  pseudoxml  to make pseudoxml-XML files for display purposes
-	echo.  linkcheck  to check all external links for integrity
-	echo.  doctest    to run all doctests embedded in the documentation if enabled
-	echo.  coverage   to run coverage check of the documentation if enabled
-	goto end
+    :help
+    echo.Please use `make ^<target^>` where ^<target^> is one of
+    echo.  html       to make standalone HTML files
+    echo.  dirhtml    to make HTML files named index.html in directories
+    echo.  singlehtml to make a single large HTML file
+    echo.  pickle     to make pickle files
+    echo.  json       to make JSON files
+    echo.  htmlhelp   to make HTML files and a HTML help project
+    echo.  qthelp     to make HTML files and a qthelp project
+    echo.  devhelp    to make HTML files and a Devhelp project
+    echo.  epub       to make an epub
+    echo.  latex      to make LaTeX files, you can set PAPER=a4 or PAPER=letter
+    echo.  text       to make text files
+    echo.  man        to make manual pages
+    echo.  texinfo    to make Texinfo files
+    echo.  gettext    to make PO message catalogs
+    echo.  changes    to make an overview over all changed/added/deprecated items
+    echo.  xml        to make Docutils-native XML files
+    echo.  pseudoxml  to make pseudoxml-XML files for display purposes
+    echo.  linkcheck  to check all external links for integrity
+    echo.  doctest    to run all doctests embedded in the documentation if enabled
+    echo.  coverage   to run coverage check of the documentation if enabled
+    goto end
 )
 
 if "%1" == "clean" (
-	for /d %%i in (%BUILDDIR%\*) do rmdir /q /s %%i
-	del /q /s %BUILDDIR%\*
-	goto end
+    for /d %%i in (%BUILDDIR%\*) do rmdir /q /s %%i
+    del /q /s %BUILDDIR%\*
+    goto end
 )
 
 
@@ -58,206 +58,206 @@ goto sphinx_ok
 set SPHINXBUILD=python -m sphinx.__init__
 %SPHINXBUILD% 2> nul
 if errorlevel 9009 (
-	echo.
-	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
-	echo.installed, then set the SPHINXBUILD environment variable to point
-	echo.to the full path of the 'sphinx-build' executable. Alternatively you
-	echo.may add the Sphinx directory to PATH.
-	echo.
-	echo.If you don't have Sphinx installed, grab it from
-	echo.http://sphinx-doc.org/
-	exit /b 1
+    echo.
+    echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+    echo.installed, then set the SPHINXBUILD environment variable to point
+    echo.to the full path of the 'sphinx-build' executable. Alternatively you
+    echo.may add the Sphinx directory to PATH.
+    echo.
+    echo.If you don't have Sphinx installed, grab it from
+    echo.http://sphinx-doc.org/
+    exit /b 1
 )
 
 :sphinx_ok
 
 
 if "%1" == "html" (
-	%SPHINXBUILD% -b html %ALLSPHINXOPTS% %BUILDDIR%/html
-	if errorlevel 1 exit /b 1
-	echo.
-	echo.Build finished. The HTML pages are in %BUILDDIR%/html.
-	goto end
+    %SPHINXBUILD% -b html %ALLSPHINXOPTS% %BUILDDIR%/html
+    if errorlevel 1 exit /b 1
+    echo.
+    echo.Build finished. The HTML pages are in %BUILDDIR%/html.
+    goto end
 )
 
 if "%1" == "dirhtml" (
-	%SPHINXBUILD% -b dirhtml %ALLSPHINXOPTS% %BUILDDIR%/dirhtml
-	if errorlevel 1 exit /b 1
-	echo.
-	echo.Build finished. The HTML pages are in %BUILDDIR%/dirhtml.
-	goto end
+    %SPHINXBUILD% -b dirhtml %ALLSPHINXOPTS% %BUILDDIR%/dirhtml
+    if errorlevel 1 exit /b 1
+    echo.
+    echo.Build finished. The HTML pages are in %BUILDDIR%/dirhtml.
+    goto end
 )
 
 if "%1" == "singlehtml" (
-	%SPHINXBUILD% -b singlehtml %ALLSPHINXOPTS% %BUILDDIR%/singlehtml
-	if errorlevel 1 exit /b 1
-	echo.
-	echo.Build finished. The HTML pages are in %BUILDDIR%/singlehtml.
-	goto end
+    %SPHINXBUILD% -b singlehtml %ALLSPHINXOPTS% %BUILDDIR%/singlehtml
+    if errorlevel 1 exit /b 1
+    echo.
+    echo.Build finished. The HTML pages are in %BUILDDIR%/singlehtml.
+    goto end
 )
 
 if "%1" == "pickle" (
-	%SPHINXBUILD% -b pickle %ALLSPHINXOPTS% %BUILDDIR%/pickle
-	if errorlevel 1 exit /b 1
-	echo.
-	echo.Build finished; now you can process the pickle files.
-	goto end
+    %SPHINXBUILD% -b pickle %ALLSPHINXOPTS% %BUILDDIR%/pickle
+    if errorlevel 1 exit /b 1
+    echo.
+    echo.Build finished; now you can process the pickle files.
+    goto end
 )
 
 if "%1" == "json" (
-	%SPHINXBUILD% -b json %ALLSPHINXOPTS% %BUILDDIR%/json
-	if errorlevel 1 exit /b 1
-	echo.
-	echo.Build finished; now you can process the JSON files.
-	goto end
+    %SPHINXBUILD% -b json %ALLSPHINXOPTS% %BUILDDIR%/json
+    if errorlevel 1 exit /b 1
+    echo.
+    echo.Build finished; now you can process the JSON files.
+    goto end
 )
 
 if "%1" == "htmlhelp" (
-	%SPHINXBUILD% -b htmlhelp %ALLSPHINXOPTS% %BUILDDIR%/htmlhelp
-	if errorlevel 1 exit /b 1
-	echo.
-	echo.Build finished; now you can run HTML Help Workshop with the ^
+    %SPHINXBUILD% -b htmlhelp %ALLSPHINXOPTS% %BUILDDIR%/htmlhelp
+    if errorlevel 1 exit /b 1
+    echo.
+    echo.Build finished; now you can run HTML Help Workshop with the ^
 .hhp project file in %BUILDDIR%/htmlhelp.
-	goto end
+    goto end
 )
 
 if "%1" == "qthelp" (
-	%SPHINXBUILD% -b qthelp %ALLSPHINXOPTS% %BUILDDIR%/qthelp
-	if errorlevel 1 exit /b 1
-	echo.
-	echo.Build finished; now you can run "qcollectiongenerator" with the ^
+    %SPHINXBUILD% -b qthelp %ALLSPHINXOPTS% %BUILDDIR%/qthelp
+    if errorlevel 1 exit /b 1
+    echo.
+    echo.Build finished; now you can run "qcollectiongenerator" with the ^
 .qhcp project file in %BUILDDIR%/qthelp, like this:
-	echo.^> qcollectiongenerator %BUILDDIR%\qthelp\testy_sphinxy.qhcp
-	echo.To view the help file:
-	echo.^> assistant -collectionFile %BUILDDIR%\qthelp\testy_sphinxy.ghc
-	goto end
+    echo.^> qcollectiongenerator %BUILDDIR%\qthelp\testy_sphinxy.qhcp
+    echo.To view the help file:
+    echo.^> assistant -collectionFile %BUILDDIR%\qthelp\testy_sphinxy.ghc
+    goto end
 )
 
 if "%1" == "devhelp" (
-	%SPHINXBUILD% -b devhelp %ALLSPHINXOPTS% %BUILDDIR%/devhelp
-	if errorlevel 1 exit /b 1
-	echo.
-	echo.Build finished.
-	goto end
+    %SPHINXBUILD% -b devhelp %ALLSPHINXOPTS% %BUILDDIR%/devhelp
+    if errorlevel 1 exit /b 1
+    echo.
+    echo.Build finished.
+    goto end
 )
 
 if "%1" == "epub" (
-	%SPHINXBUILD% -b epub %ALLSPHINXOPTS% %BUILDDIR%/epub
-	if errorlevel 1 exit /b 1
-	echo.
-	echo.Build finished. The epub file is in %BUILDDIR%/epub.
-	goto end
+    %SPHINXBUILD% -b epub %ALLSPHINXOPTS% %BUILDDIR%/epub
+    if errorlevel 1 exit /b 1
+    echo.
+    echo.Build finished. The epub file is in %BUILDDIR%/epub.
+    goto end
 )
 
 if "%1" == "latex" (
-	%SPHINXBUILD% -b latex %ALLSPHINXOPTS% %BUILDDIR%/latex
-	if errorlevel 1 exit /b 1
-	echo.
-	echo.Build finished; the LaTeX files are in %BUILDDIR%/latex.
-	goto end
+    %SPHINXBUILD% -b latex %ALLSPHINXOPTS% %BUILDDIR%/latex
+    if errorlevel 1 exit /b 1
+    echo.
+    echo.Build finished; the LaTeX files are in %BUILDDIR%/latex.
+    goto end
 )
 
 if "%1" == "latexpdf" (
-	%SPHINXBUILD% -b latex %ALLSPHINXOPTS% %BUILDDIR%/latex
-	cd %BUILDDIR%/latex
-	make all-pdf
-	cd %~dp0
-	echo.
-	echo.Build finished; the PDF files are in %BUILDDIR%/latex.
-	goto end
+    %SPHINXBUILD% -b latex %ALLSPHINXOPTS% %BUILDDIR%/latex
+    cd %BUILDDIR%/latex
+    make all-pdf
+    cd %~dp0
+    echo.
+    echo.Build finished; the PDF files are in %BUILDDIR%/latex.
+    goto end
 )
 
 if "%1" == "latexpdfja" (
-	%SPHINXBUILD% -b latex %ALLSPHINXOPTS% %BUILDDIR%/latex
-	cd %BUILDDIR%/latex
-	make all-pdf-ja
-	cd %~dp0
-	echo.
-	echo.Build finished; the PDF files are in %BUILDDIR%/latex.
-	goto end
+    %SPHINXBUILD% -b latex %ALLSPHINXOPTS% %BUILDDIR%/latex
+    cd %BUILDDIR%/latex
+    make all-pdf-ja
+    cd %~dp0
+    echo.
+    echo.Build finished; the PDF files are in %BUILDDIR%/latex.
+    goto end
 )
 
 if "%1" == "text" (
-	%SPHINXBUILD% -b text %ALLSPHINXOPTS% %BUILDDIR%/text
-	if errorlevel 1 exit /b 1
-	echo.
-	echo.Build finished. The text files are in %BUILDDIR%/text.
-	goto end
+    %SPHINXBUILD% -b text %ALLSPHINXOPTS% %BUILDDIR%/text
+    if errorlevel 1 exit /b 1
+    echo.
+    echo.Build finished. The text files are in %BUILDDIR%/text.
+    goto end
 )
 
 if "%1" == "man" (
-	%SPHINXBUILD% -b man %ALLSPHINXOPTS% %BUILDDIR%/man
-	if errorlevel 1 exit /b 1
-	echo.
-	echo.Build finished. The manual pages are in %BUILDDIR%/man.
-	goto end
+    %SPHINXBUILD% -b man %ALLSPHINXOPTS% %BUILDDIR%/man
+    if errorlevel 1 exit /b 1
+    echo.
+    echo.Build finished. The manual pages are in %BUILDDIR%/man.
+    goto end
 )
 
 if "%1" == "texinfo" (
-	%SPHINXBUILD% -b texinfo %ALLSPHINXOPTS% %BUILDDIR%/texinfo
-	if errorlevel 1 exit /b 1
-	echo.
-	echo.Build finished. The Texinfo files are in %BUILDDIR%/texinfo.
-	goto end
+    %SPHINXBUILD% -b texinfo %ALLSPHINXOPTS% %BUILDDIR%/texinfo
+    if errorlevel 1 exit /b 1
+    echo.
+    echo.Build finished. The Texinfo files are in %BUILDDIR%/texinfo.
+    goto end
 )
 
 if "%1" == "gettext" (
-	%SPHINXBUILD% -b gettext %I18NSPHINXOPTS% %BUILDDIR%/locale
-	if errorlevel 1 exit /b 1
-	echo.
-	echo.Build finished. The message catalogs are in %BUILDDIR%/locale.
-	goto end
+    %SPHINXBUILD% -b gettext %I18NSPHINXOPTS% %BUILDDIR%/locale
+    if errorlevel 1 exit /b 1
+    echo.
+    echo.Build finished. The message catalogs are in %BUILDDIR%/locale.
+    goto end
 )
 
 if "%1" == "changes" (
-	%SPHINXBUILD% -b changes %ALLSPHINXOPTS% %BUILDDIR%/changes
-	if errorlevel 1 exit /b 1
-	echo.
-	echo.The overview file is in %BUILDDIR%/changes.
-	goto end
+    %SPHINXBUILD% -b changes %ALLSPHINXOPTS% %BUILDDIR%/changes
+    if errorlevel 1 exit /b 1
+    echo.
+    echo.The overview file is in %BUILDDIR%/changes.
+    goto end
 )
 
 if "%1" == "linkcheck" (
-	%SPHINXBUILD% -b linkcheck %ALLSPHINXOPTS% %BUILDDIR%/linkcheck
-	if errorlevel 1 exit /b 1
-	echo.
-	echo.Link check complete; look for any errors in the above output ^
+    %SPHINXBUILD% -b linkcheck %ALLSPHINXOPTS% %BUILDDIR%/linkcheck
+    if errorlevel 1 exit /b 1
+    echo.
+    echo.Link check complete; look for any errors in the above output ^
 or in %BUILDDIR%/linkcheck/output.txt.
-	goto end
+    goto end
 )
 
 if "%1" == "doctest" (
-	%SPHINXBUILD% -b doctest %ALLSPHINXOPTS% %BUILDDIR%/doctest
-	if errorlevel 1 exit /b 1
-	echo.
-	echo.Testing of doctests in the sources finished, look at the ^
+    %SPHINXBUILD% -b doctest %ALLSPHINXOPTS% %BUILDDIR%/doctest
+    if errorlevel 1 exit /b 1
+    echo.
+    echo.Testing of doctests in the sources finished, look at the ^
 results in %BUILDDIR%/doctest/output.txt.
-	goto end
+    goto end
 )
 
 if "%1" == "coverage" (
-	%SPHINXBUILD% -b coverage %ALLSPHINXOPTS% %BUILDDIR%/coverage
-	if errorlevel 1 exit /b 1
-	echo.
-	echo.Testing of coverage in the sources finished, look at the ^
+    %SPHINXBUILD% -b coverage %ALLSPHINXOPTS% %BUILDDIR%/coverage
+    if errorlevel 1 exit /b 1
+    echo.
+    echo.Testing of coverage in the sources finished, look at the ^
 results in %BUILDDIR%/coverage/python.txt.
-	goto end
+    goto end
 )
 
 if "%1" == "xml" (
-	%SPHINXBUILD% -b xml %ALLSPHINXOPTS% %BUILDDIR%/xml
-	if errorlevel 1 exit /b 1
-	echo.
-	echo.Build finished. The XML files are in %BUILDDIR%/xml.
-	goto end
+    %SPHINXBUILD% -b xml %ALLSPHINXOPTS% %BUILDDIR%/xml
+    if errorlevel 1 exit /b 1
+    echo.
+    echo.Build finished. The XML files are in %BUILDDIR%/xml.
+    goto end
 )
 
 if "%1" == "pseudoxml" (
-	%SPHINXBUILD% -b pseudoxml %ALLSPHINXOPTS% %BUILDDIR%/pseudoxml
-	if errorlevel 1 exit /b 1
-	echo.
-	echo.Build finished. The pseudo-XML files are in %BUILDDIR%/pseudoxml.
-	goto end
+    %SPHINXBUILD% -b pseudoxml %ALLSPHINXOPTS% %BUILDDIR%/pseudoxml
+    if errorlevel 1 exit /b 1
+    echo.
+    echo.Build finished. The pseudo-XML files are in %BUILDDIR%/pseudoxml.
+    goto end
 )
 
 :end

--- a/doc/source/reference/language/functions.rst
+++ b/doc/source/reference/language/functions.rst
@@ -141,7 +141,7 @@ The expression is evaluated in this order: derefexp after the explist (arguments
 the end the call.
 
 A function call in Squirrel passes the current environment object *this* as a hidden parameter.
-But when the function was immediately indexed from an object, *this* shall be the object 
+But when the function was immediately indexed from an object, *this* shall be the object
 which was indexed, instead.
 
 If we call a function with the syntax::
@@ -156,7 +156,7 @@ Whereas with the syntax::
 
 the environment object will be the current *this* (that is, propagated from the caller's *this*).
 
-It may help to remember the rules in the following way: 
+It may help to remember the rules in the following way:
 
     foo(x,y) ---> this.foo(x,y)
     table.foo(x,y) ---> call foo with (table,x,y)

--- a/doc/source/stdlib/stdstringlib.rst
+++ b/doc/source/stdlib/stdstringlib.rst
@@ -17,7 +17,7 @@ Global Symbols
 .. js:function:: endswith(str, cmp)
 
     returns `true` if the end of the string `str`  matches a the string `cmp` otherwise returns `false`
-	
+
 .. js:function:: escape(str)
 
     Returns a string with backslashes before characters that need to be escaped(`\",\a,\b,\t,\n,\v,\f,\r,\\,\",\',\0,\xnn`).
@@ -66,7 +66,7 @@ Global Symbols
 .. js:function:: startswith(str, cmp)
 
     returns `true` if the beginning of the string `str` matches the string `cmp`; otherwise returns `false`
-	
+
 .. js:function:: strip(str)
 
     Strips white-space-only characters that might appear at the beginning or end of the given string and returns the new stripped string.

--- a/sqstdlib/sqstdio.cpp
+++ b/sqstdlib/sqstdio.cpp
@@ -401,7 +401,7 @@ SQRESULT sqstd_dofile(HSQUIRRELVM v,const SQChar *filename,SQBool retval,SQBool 
 {
     //at least one entry must exist in order for us to push it as the environment
     if(sq_gettop(v) == 0)
-        return sq_throwerror(v,_SC("environment table expected"));	
+        return sq_throwerror(v,_SC("environment table expected"));
 
     if(SQ_SUCCEEDED(sqstd_loadfile(v,filename,printerror))) {
         sq_push(v,-2);

--- a/sqstdlib/sqstdrex.cpp
+++ b/sqstdlib/sqstdrex.cpp
@@ -155,7 +155,7 @@ static SQInteger sqstd_rex_charnode(SQRex *exp,SQBool isclass)
                 }
             case 0:
                 sqstd_rex_error(exp,_SC("letter expected for argument of escape sequence"));
-                break;                
+                break;
             case 'b':
             case 'B':
                 if(!isclass) {

--- a/sqstdlib/sqstdstring.cpp
+++ b/sqstdlib/sqstdstring.cpp
@@ -156,7 +156,7 @@ static SQInteger _string_printf(HSQUIRRELVM v)
     SQInteger length = 0;
     if(SQ_FAILED(sqstd_format(v,2,&length,&dest)))
         return -1;
-    
+
     SQPRINTFUNCTION printfunc = sq_getprintfunc(v);
     if(printfunc) printfunc(v,dest);
 

--- a/squirrel/sqlexer.cpp
+++ b/squirrel/sqlexer.cpp
@@ -68,7 +68,7 @@ void SQLexer::Init(SQSharedState *ss, SQLEXREADFUNC rg, SQUserPointer up,Compile
     ADD_KEYWORD(__LINE__,TK___LINE__);
     ADD_KEYWORD(__FILE__,TK___FILE__);
     ADD_KEYWORD(rawcall, TK_RAWCALL);
-    
+
 
     _readf = rg;
     _up = up;


### PR DESCRIPTION
Convert source files to Unix EOL mode, convert .bat files to DOS EOL
mode, de-tabify and strip trailing whitespace.