### PR TITLE
Failed assertion in compiler

### DIFF
--- a/squirrel/sqcompiler.cpp
+++ b/squirrel/sqcompiler.cpp
@@ -459,6 +459,7 @@ public:
         _es.donot_get = false;
         (this->*f)();
         _es = es;
+	  _es.etype     = EXPR;
     }
     template<typename T> void BIN_EXP(SQOpcode op, T f,SQInteger op3 = 0)
     {


### PR DESCRIPTION
The attached script code leads to a failed assertion 
``
sq: sqfuncstate.cpp:291: SQInteger SQFuncState::PopTarget(): Assertion `npos < _vlocals.size()' failed.
``
The failing instruction is
``
if (j==0  &&  a=0)
``
Here the compiler tries to assign a value to the expression 'j==0  && a', and treats this expression as local variable instead of EXPR. 

My proposed solution is to set expression state to EXPR at the end of INVOKE_EXP