### PR TITLE
Fix building as a git submodule.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ set(CMAKE_BUILD_TYPE "Release" CACHE STRING "")
 
 project(squirrel C CXX)
 
-include_directories(${CMAKE_SOURCE_DIR}/include)
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
 
 if(CMAKE_COMPILER_IS_GNUCXX)
   set(SQ_FLAGS -fno-exceptions -fno-strict-aliasing -Wall -Wextra -pedantic -Wcast-qual)


### PR DESCRIPTION
CMAKE_SOURCE_DIR points at the root project's source dir,
which is wrong when building squirrel as a git submodule.
CMAKE_CURRENT_SOURCE_DIR points at the dir of the current
CMakeLists.txt and thus should be used most of the time.