### PR TITLE
configurable makefile vars from command line

### DIFF
--- a/sqstdlib/Makefile
+++ b/sqstdlib/Makefile
@@ -1,8 +1,10 @@
 SQUIRREL= ..
 
 
-OUT= $(SQUIRREL)/lib/libsqstdlib.a
-INCZ= -I$(SQUIRREL)/include -I. -Iinclude
+OUT?= $(SQUIRREL)/lib/libsqstdlib.a
+INCZ?= -I$(SQUIRREL)/include -I. -Iinclude
+DEFS= $(CC_EXTRA_FLAGS)
+LIB=
 
 OBJS= \
 	sqstdblob.o \
@@ -26,16 +28,16 @@ SRCS= \
 
 
 sq32:
-	gcc -O2 -fno-exceptions -fno-rtti -Wall -fno-strict-aliasing -c $(SRCS) $(INCZ)
+	gcc -O2 -fno-exceptions -fno-rtti -Wall -fno-strict-aliasing -c $(SRCS) $(INCZ) $(DEFS)
 	ar rc $(OUT) *.o
 	rm *.o
 
 sqprof:
-	gcc -O2 -pg -fno-exceptions -fno-rtti -pie -gstabs -g3 -Wall -fno-strict-aliasing -c $(SRCS) $(INCZ)
+	gcc -O2 -pg -fno-exceptions -fno-rtti -pie -gstabs -g3 -Wall -fno-strict-aliasing -c $(SRCS) $(INCZ) $(DEFS)
 	ar rc $(OUT) *.o
 	rm *.o
 
 sq64:
-	gcc -O2 -m64 -fno-exceptions -D_SQ64 -fno-rtti -Wall -fno-strict-aliasing -c $(SRCS) $(INCZ)
+	gcc -O2 -m64 -fno-exceptions -D_SQ64 -fno-rtti -Wall -fno-strict-aliasing -c $(SRCS) $(INCZ) $(DEFS)
 	ar rc $(OUT) *.o
 	rm *.o

--- a/squirrel/Makefile
+++ b/squirrel/Makefile
@@ -1,9 +1,9 @@
 SQUIRREL= ..
 
 
-OUT= $(SQUIRREL)/lib/libsquirrel.a
-INCZ= -I$(SQUIRREL)/include -I. -Iinclude
-DEFS=
+OUT?= $(SQUIRREL)/lib/libsquirrel.a
+INCZ?= -I$(SQUIRREL)/include -I. -Iinclude
+DEFS= $(CC_EXTRA_FLAGS)
 LIB=
 
 OBJS= \


### PR DESCRIPTION
Updated the Makefiles in squirrel and sqstdlib folder to have same set of variables in order to be more coherent as well as be able to pass their values from command line.

The variables OUT and INCZ can be set from command line, while DEFS can be set via CC_EXTRA_FLAGS -- I was not sure if the purpose of the existing `DEFS= ` was to reset an eventual existing value, given that DEFS is quite common out there in build systems. If the purpose was not to reset DEFS, then it can be set to `DEFS?=` and CC_EXTRA_FLAGS won't be needed.

The target is to make it easier to embed the interpreter directly into another project source code tree by just copying the two folders. The build system of the host project then can set these variables when invoking make for squirrel, to set custom compile flags and output paths.