### PR TITLE
remove redundant sq_type macro, use sqtype instead

### DIFF
--- a/include/squirrel.h
+++ b/include/squirrel.h
@@ -386,7 +386,6 @@ SQUIRREL_API void sq_setnativedebughook(HSQUIRRELVM v,SQDEBUGHOOK hook);
 #define sq_isinstance(o) ((o)._type==OT_INSTANCE)
 #define sq_isbool(o) ((o)._type==OT_BOOL)
 #define sq_isweakref(o) ((o)._type==OT_WEAKREF)
-#define sq_type(o) ((o)._type)
 
 /* deprecated */
 #define sq_createslot(v,n) sq_newslot(v,n,SQFalse)

--- a/squirrel/sqapi.cpp
+++ b/squirrel/sqapi.cpp
@@ -188,7 +188,7 @@ SQUnsignedInteger sq_getvmrefcount(HSQUIRRELVM SQ_UNUSED_ARG(v), const HSQOBJECT
 
 const SQChar *sq_objtostring(const HSQOBJECT *o)
 {
-    if(sq_type(*o) == OT_STRING) {
+    if(sqtype(*o) == OT_STRING) {
         return _stringval(*o);
     }
     return NULL;


### PR DESCRIPTION
The sq_type macro was already sitting in the code. This patch removes it in favor of the recently added sqtype macro.