### PR TITLE
sq_newmember and sq_rawnewmember argument popping

### DIFF
--- a/squirrel/sqapi.cpp
+++ b/squirrel/sqapi.cpp
@@ -947,8 +947,11 @@ SQRESULT sq_newmember(HSQUIRRELVM v,SQInteger idx,SQBool bstatic)
     if(sq_type(self) != OT_CLASS) return sq_throwerror(v, _SC("new member only works with classes"));
     SQObjectPtr &key = v->GetUp(-3);
     if(sq_type(key) == OT_NULL) return sq_throwerror(v, _SC("null key"));
-    if(!v->NewSlotA(self,key,v->GetUp(-2),v->GetUp(-1),bstatic?true:false,false))
+    if(!v->NewSlotA(self,key,v->GetUp(-2),v->GetUp(-1),bstatic?true:false,false)) {
+        v->Pop(3);
         return SQ_ERROR;
+    }
+    v->Pop(3);
     return SQ_OK;
 }
 
@@ -958,8 +961,11 @@ SQRESULT sq_rawnewmember(HSQUIRRELVM v,SQInteger idx,SQBool bstatic)
     if(sq_type(self) != OT_CLASS) return sq_throwerror(v, _SC("new member only works with classes"));
     SQObjectPtr &key = v->GetUp(-3);
     if(sq_type(key) == OT_NULL) return sq_throwerror(v, _SC("null key"));
-    if(!v->NewSlotA(self,key,v->GetUp(-2),v->GetUp(-1),bstatic?true:false,true))
+    if(!v->NewSlotA(self,key,v->GetUp(-2),v->GetUp(-1),bstatic?true:false,true)) {
+        v->Pop(3);
         return SQ_ERROR;
+    }
+    v->Pop(3);
     return SQ_OK;
 }
 


### PR DESCRIPTION
This PR fixes a bug where sq_newmember and sq_rawnewmember did not pop their arguments from the stack. This makes it comply with the documentation (http://www.squirrel-lang.org/squirreldoc/reference/api/object_manipulation.html?highlight=newmember#c.sq_newmember).

Changing this function might break existing code and I also haven't tested it much (yet). Please advise.
An alternate route is to update the wording in the documentation if we don't want to arguments to be popped.