### PR TITLE
Fix errors in documentation source code

### DIFF
--- a/doc/source/reference/embedding/references_from_c.rst
+++ b/doc/source/reference/embedding/references_from_c.rst
@@ -11,11 +11,11 @@ The object can be also re-pushed in the VM stack using sq_pushobject().::
 
     HSQOBJECT obj;
 
-    sq_resetobject(v,&obj) //initialize the handle
+    sq_resetobject(&obj) //initialize the handle
     sq_getstackobj(v,-2,&obj); //retrieve an object handle from the pos -2
     sq_addref(v,&obj); //adds a reference to the object
 
     ... //do stuff
 
-    sq_pushobject(v,&obj); //push the object in the stack
+    sq_pushobject(v,obj); //push the object in the stack
     sq_release(v,&obj); //relese the object


### PR DESCRIPTION
In order to make the examples compile in master on windows I had to change this.