### PR TITLE
Fix some small bugs in the documentation examples

### DIFF
--- a/doc/source/reference/api/object_manipulation.rst
+++ b/doc/source/reference/api/object_manipulation.rst
@@ -164,7 +164,7 @@ pops a key from the stack and delete the slot indexed by it from the table at po
     :param HSQUIRRELVM v: the target VM
     :param SQInteger idx: index of the target object in the stack
     :returns: a SQRESULT
-    :remarks: this call will invokes the delegation system like a normal dereference it only works on tables, arrays and userdata; if the function fails, nothing will be pushed in the stack.
+    :remarks: this call will invokes the delegation system like a normal dereference it only works on tables, arrays, classes, instances and userdata; if the function fails, nothing will be pushed in the stack.
 
 pops a key from the stack and performs a get operation on the object at the position idx in the stack; and pushes the result in the stack.
 

--- a/doc/source/reference/embedding/calling_a_function.rst
+++ b/doc/source/reference/embedding/calling_a_function.rst
@@ -16,7 +16,7 @@ parameter is > 0. ::
     sq_pushinteger(v,1);
     sq_pushfloat(v,2.0);
     sq_pushstring(v,"three",-1);
-    sq_call(v,4,SQFalse);
+    sq_call(v,4,SQFalse,SQFalse);
     sq_pop(v,2); //pops the roottable and the function
 
 this is equivalent to the following Squirrel code::

--- a/doc/source/reference/embedding/compiling_a_script.rst
+++ b/doc/source/reference/embedding/compiling_a_script.rst
@@ -8,7 +8,7 @@ You can compile a Squirrel script with the function *sq_compile*.::
 
     typedef SQInteger (*SQLEXREADFUNC)(SQUserPointer userdata);
 
-    SQRESULT sq_compile(HSQUIRRELVM v,SQREADFUNC read,SQUserPointer p,
+    SQRESULT sq_compile(HSQUIRRELVM v,SQLEXREADFUNC read,SQUserPointer p,
                 const SQChar *sourcename,SQBool raiseerror);
 
 In order to compile a script is necessary for the host application to implement a reader

--- a/doc/source/reference/embedding/creating_a_c_function.rst
+++ b/doc/source/reference/embedding/creating_a_c_function.rst
@@ -99,7 +99,8 @@ Here an example of how to register a function::
     {
         sq_pushroottable(v);
         sq_pushstring(v,fname,-1);
-        sq_newclosure(v,f,0,0); //create a new function
+        sq_newclosure(v,f,0); //create a new function
         sq_newslot(v,-3,SQFalse);
         sq_pop(v,1); //pops the root table
+        return 0;
     }

--- a/doc/source/reference/embedding/references_from_c.rst
+++ b/doc/source/reference/embedding/references_from_c.rst
@@ -11,7 +11,7 @@ The object can be also re-pushed in the VM stack using sq_pushobject().::
 
     HSQOBJECT obj;
 
-    sq_resetobject(&obj) //initialize the handle
+    sq_resetobject(&obj); //initialize the handle
     sq_getstackobj(v,-2,&obj); //retrieve an object handle from the pos -2
     sq_addref(v,&obj); //adds a reference to the object
 


### PR DESCRIPTION
Here are the bugs I found in the embedding-part of the documentation in doing my documentation tests (see PR #115 ). I also snuck in some more information in sq_get, let me know I am mistaken.

Not fixed:

In compiling_a_c_function.rst the line "printf("arg %d is ",n);" is not 64-bit compatible but I don't have a good clean fix for that.