### PR TITLE
fix for crash for functions with > 127 local vars

### DIFF
--- a/squirrel/sqcompiler.cpp
+++ b/squirrel/sqcompiler.cpp
@@ -939,7 +939,10 @@ public:
          for(SQInteger i = 0; i < (nargs - 1); i++) _fs->PopTarget();
          SQInteger stackbase = _fs->PopTarget();
          SQInteger closure = _fs->PopTarget();
-         _fs->AddInstruction(_OP_CALL, _fs->PushTarget(), closure, stackbase, nargs);
+         SQInteger target = _fs->PushTarget();
+         assert(target >= -1);
+         assert(target < 255);
+         _fs->AddInstruction(_OP_CALL, target, closure, stackbase, nargs);
     }
     void ParseTableOrClass(SQInteger separator,SQInteger terminator)
     {

--- a/squirrel/sqvm.cpp
+++ b/squirrel/sqvm.cpp
@@ -738,32 +738,33 @@ exception_restore:
                               }
             case _OP_CALL: {
                     SQObjectPtr clo = STK(arg1);
+                    int tgt0 = arg0 == 255 ? -1 : arg0;
                     switch (sq_type(clo)) {
                     case OT_CLOSURE:
-                        _GUARD(StartCall(_closure(clo), sarg0, arg3, _stackbase+arg2, false));
+                        _GUARD(StartCall(_closure(clo), tgt0, arg3, _stackbase+arg2, false));
                         continue;
                     case OT_NATIVECLOSURE: {
                         bool suspend;
 						bool tailcall;
-                        _GUARD(CallNative(_nativeclosure(clo), arg3, _stackbase+arg2, clo, (SQInt32)sarg0, suspend, tailcall));
+                        _GUARD(CallNative(_nativeclosure(clo), arg3, _stackbase+arg2, clo, tgt0, suspend, tailcall));
                         if(suspend){
                             _suspended = SQTrue;
-                            _suspended_target = sarg0;
+                            _suspended_target = tgt0;
                             _suspended_root = ci->_root;
                             _suspended_traps = traps;
                             outres = clo;
                             return true;
                         }
-                        if(sarg0 != -1 && !tailcall) {
-                            STK(arg0) = clo;
+                        if(tgt0 != -1 && !tailcall) {
+                            STK(tgt0) = clo;
                         }
                                            }
                         continue;
                     case OT_CLASS:{
                         SQObjectPtr inst;
                         _GUARD(CreateClassInstance(_class(clo),inst,clo));
-                        if(sarg0 != -1) {
-                            STK(arg0) = inst;
+                        if(tgt0 != -1) {
+                            STK(tgt0) = inst;
                         }
                         SQInteger stkbase;
                         switch(sq_type(clo)) {
@@ -790,8 +791,8 @@ exception_restore:
                             Push(clo);
                             for (SQInteger i = 0; i < arg3; i++) Push(STK(arg2 + i));
                             if(!CallMetaMethod(closure, MT_CALL, arg3+1, clo)) SQ_THROW();
-                            if(sarg0 != -1) {
-                                STK(arg0) = clo;
+                            if(tgt0 != -1) {
+                                STK(tgt0) = clo;
                             }
                             break;
                         }


### PR DESCRIPTION
Actual crash happened due to _OP_CALL target argument is overflowed
signed char (7 bit). Treat argument as as unsigned (with exception of
value -1/255 which is special) in order to fix it