### PR TITLE
Fix for enums with initialization

### DIFF
--- a/squirrel/sqcompiler.cpp
+++ b/squirrel/sqcompiler.cpp
@@ -1365,6 +1365,7 @@ public:
             if(_token == _SC('=')) {
                 Lex();
                 val = ExpectScalar();
+                nval = _integer(val)+1;
             }
             else {
                 val._type = OT_INTEGER;


### PR DESCRIPTION
There is a bug in squirrel on enums with initialization see the example bellow:
```
enum option_type { OPT_FLAG=1,  OPT_INT,  OPT_DBL,  OPT_STR,
         OPT_FFLAG, OPT_FINT, OPT_FDBL, OPT_FSTR};

print("\nOPT_FLAG " + option_type.OPT_FLAG);
print("\nOPT_INT " + option_type.OPT_INT);
print("\nOPT_DBL " + option_type.OPT_DBL);
```
Without the fix the output is:
```
OPT_FLAG 1
OPT_INT 0
OPT_DBL 1
```
With the fix:
```
OPT_FLAG 1
OPT_INT 2
OPT_DBL 3
```
Cheers !