### PR TITLE
Accept multiline string continuation

### DIFF
--- a/squirrel/sqcompiler.cpp
+++ b/squirrel/sqcompiler.cpp
@@ -1365,6 +1365,7 @@ public:
             if(_token == _SC('=')) {
                 Lex();
                 val = ExpectScalar();
+                nval = _integer(val)+1;
             }
             else {
                 val._type = OT_INTEGER;

--- a/squirrel/sqlexer.cpp
+++ b/squirrel/sqlexer.cpp
@@ -409,6 +409,13 @@ SQInteger SQLexer::ReadString(SQInteger ndelim,bool verbatim)
                     case _SC('\\'): APPEND_CHAR(_SC('\\')); NEXT(); break;
                     case _SC('"'): APPEND_CHAR(_SC('"')); NEXT(); break;
                     case _SC('\''): APPEND_CHAR(_SC('\'')); NEXT(); break;
+                    case _SC('\n'):
+                        if(ndelim == _SC('"')){
+                          _currentline++;
+                          NEXT();
+                          break;
+                        }
+                        //fallthrough
                     default:
                         Error(_SC("unrecognised escaper char"));
                     break;


### PR DESCRIPTION
With this patch squirrel can accept multiline string continuation like C/C++/Shell:
```
local str = "one line \
with continuation";
print(str);
```