### PR TITLE
now container modification methods return object itself in all cases

### DIFF
--- a/doc/source/reference/language/builtin_functions.rst
+++ b/doc/source/reference/language/builtin_functions.rst
@@ -279,7 +279,7 @@ tries to get a value from the slot 'key' without employing delegation
 
 .. js:function:: table.rawset(key,val)
 
-Sets the slot 'key' with the value 'val' without employing delegation. If the slot does not exists, it will be created.
+Sets the slot 'key' with the value 'val' without employing delegation. If the slot does not exists, it will be created. Returns table itself.
 
 
 .. js:function:: table.rawdelete()
@@ -304,7 +304,7 @@ Tries to invoke the _tostring metamethod. If that fails, it returns "(table : po
 
 .. js:function:: table.clear()
 
-removes all the slots from the table
+removes all the slots from the table. Returns table itself.
 
 
 .. js:function:: table.setdelegate(table)
@@ -332,17 +332,17 @@ returns the length of the array
 
 .. js:function:: array.append(val)
 
-appends the value 'val' at the end of the array
+appends the value 'val' at the end of the array. Returns array itself.
 
 
 .. js:function:: array.push(val)
 
-appends the value 'val' at the end of the array
+appends the value 'val' at the end of the array. Returns array itself.
 
 
 .. js:function:: array.extend(array)
 
-Extends the array by appending all the items in the given array.
+Extends the array by appending all the items in the given array. Returns array itself.
 
 
 .. js:function:: array.pop()
@@ -357,22 +357,22 @@ returns the value of the array with the higher index
 
 .. js:function:: array.insert(idx,val)
 
-inserts the value 'val' at the position 'idx' in the array
+inserts the value 'val' at the position 'idx' in the array. Returns array itself.
 
 
 .. js:function:: array.remove(idx)
 
-removes the value at the position 'idx' in the array
+removes the value at the position 'idx' in the array and returns its value.
 
 
 .. js:function:: array.resize(size,[fill])
 
-Resizes the array. If the optional parameter 'fill' is specified, its value will be used to fill the new array's slots when the size specified is bigger than the previous size. If the fill parameter is omitted, null is used instead.
+Resizes the array. If the optional parameter 'fill' is specified, its value will be used to fill the new array's slots when the size specified is bigger than the previous size. If the fill parameter is omitted, null is used instead. Returns array itself.
 
 
 .. js:function:: array.sort([compare_func])
 
-Sorts the array. A custom compare function can be optionally passed. The function prototype as to be the following.::
+Sorts the array in-place. A custom compare function can be optionally passed. The function prototype as to be the following.::
 
     function custom_compare(a,b)
     {
@@ -385,11 +385,11 @@ a more compact version of a custom compare can be written using a lambda express
 
     arr.sort(@(a,b) a <=> b);
 
-
+Returns array itself.
 
 .. js:function:: array.reverse()
 
-reverse the elements of the array in place
+reverse the elements of the array in place. Returns array itself.
 
 
 .. js:function:: array.slice(start,[end])

--- a/squirrel/sqbaselib.cpp
+++ b/squirrel/sqbaselib.cpp
@@ -413,7 +413,7 @@ static SQInteger obj_delegate_weakref(HSQUIRRELVM v)
 
 static SQInteger obj_clear(HSQUIRRELVM v)
 {
-    return sq_clear(v,-1);
+    return SQ_SUCCEEDED(sq_clear(v,-1)) ? 1 : SQ_ERROR;
 }
 
 
@@ -450,7 +450,7 @@ static SQInteger container_rawexists(HSQUIRRELVM v)
 
 static SQInteger container_rawset(HSQUIRRELVM v)
 {
-    return sq_rawset(v,-3);
+    return SQ_SUCCEEDED(sq_rawset(v,-3)) ? 1 : SQ_ERROR;
 }
 
 
@@ -519,18 +519,19 @@ const SQRegFunction SQSharedState::_table_default_delegate_funcz[]={
 
 static SQInteger array_append(HSQUIRRELVM v)
 {
-    return sq_arrayappend(v,-2);
+    return SQ_SUCCEEDED(sq_arrayappend(v,-2)) ? 1 : SQ_ERROR;
 }
 
 static SQInteger array_extend(HSQUIRRELVM v)
 {
     _array(stack_get(v,1))->Extend(_array(stack_get(v,2)));
-    return 0;
+    sq_pop(v,1);
+    return 1;
 }
 
 static SQInteger array_reverse(HSQUIRRELVM v)
 {
-    return sq_arrayreverse(v,-1);
+    return SQ_SUCCEEDED(sq_arrayreverse(v,-1)) ? 1 : SQ_ERROR;
 }
 
 static SQInteger array_pop(HSQUIRRELVM v)
@@ -555,7 +556,8 @@ static SQInteger array_insert(HSQUIRRELVM v)
     SQObject &val=stack_get(v,3);
     if(!_array(o)->Insert(tointeger(idx),val))
         return sq_throwerror(v,_SC("index out of range"));
-    return 0;
+    sq_pop(v,2);
+    return 1;
 }
 
 static SQInteger array_remove(HSQUIRRELVM v)
@@ -585,7 +587,8 @@ static SQInteger array_resize(HSQUIRRELVM v)
         if(sq_gettop(v) > 2)
             fill = stack_get(v, 3);
         _array(o)->Resize(sz,fill);
-        return 0;
+        sq_settop(v, 1);
+        return 1;
     }
     return sq_throwerror(v, _SC("size must be a number"));
 }
@@ -622,7 +625,8 @@ static SQInteger array_apply(HSQUIRRELVM v)
     SQObject &o = stack_get(v,1);
     if(SQ_FAILED(__map_array(_array(o),_array(o),v)))
         return SQ_ERROR;
-    return 0;
+    sq_pop(v,1);
+    return 1;
 }
 
 static SQInteger array_reduce(HSQUIRRELVM v)
@@ -789,7 +793,8 @@ static SQInteger array_sort(HSQUIRRELVM v)
             return SQ_ERROR;
 
     }
-    return 0;
+    sq_settop(v,1);
+    return 1;
 }
 
 static SQInteger array_slice(HSQUIRRELVM v)


### PR DESCRIPTION
for easy chaining
something like
local ar = [0,1,3,4]
ar.append(5).extend([6,7,8]) and etc