### PR TITLE
CMakeLists.txt: explicitly declare LONG_OUTPUT_NAMES and DISABLE_STATIC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,9 @@ else()
   cmake_minimum_required(VERSION 2.8)
 endif()
 
+option(DISABLE_STATIC "Avoid building/installing static libraries.")
+option(LONG_OUTPUT_NAMES "Use longer names for binaries and libraries: squirrel3 (not sq).")
+
 set(CMAKE_INSTALL_PREFIX "${CMAKE_SOURCE_DIR}" CACHE PATH "")
 set(CMAKE_BUILD_TYPE "Release" CACHE STRING "")
 


### PR DESCRIPTION
Toralf noticed a minor infelicity in option declarations:
```
build $ cmake -DLONG_OUTPUT_NAMES=YES ..
CMake Warning:
  Manually-specified variables were not used by the project:

    LONG_OUTPUT_NAMES
```

Note, CMake complains here about "unused" LONG_OUTPUT_NAMES.
The option is used but not declares as user-tweakable via 'option()'.

This change adds declarations for variables used in Gentoo.

Reported-by: Toralf Förster
Bug: https://bugs.gentoo.org/659880
Signed-off-by: Sergei Trofimovich <slyfox@gentoo.org>