### PR TITLE
Make params count type signed in sq_getclosureinfo()

### DIFF
--- a/doc/source/reference/api/object_creation_and_handling.rst
+++ b/doc/source/reference/api/object_creation_and_handling.rst
@@ -66,12 +66,12 @@ pushes the value of a class or instance member using a member handle (see sq_get
 
 .. _sq_getclosureinfo:
 
-.. c:function:: SQRESULT sq_getclosureinfo(HSQUIRRELVM v, SQInteger idx, SQUnsignedInteger * nparams, SQUnsignedInteger * nfreevars)
+.. c:function:: SQRESULT sq_getclosureinfo(HSQUIRRELVM v, SQInteger idx, SQInteger * nparams, SQInteger * nfreevars)
 
     :param HSQUIRRELVM v: the target VM
     :param SQInteger idx: index of the target closure
-    :param SQUnsignedInteger * nparams: a pointer to an unsigned integer that will store the number of parameters
-    :param SQUnsignedInteger * nfreevars: a pointer to an unsigned integer that will store the number of free variables
+    :param SQInteger * nparams: a pointer to an integer that will store the number of parameters
+    :param SQInteger * nfreevars: a pointer to an integer that will store the number of free variables
     :returns: an SQRESULT
 
 retrieves number of parameters and number of freevariables from a squirrel closure.

--- a/include/squirrel.h
+++ b/include/squirrel.h
@@ -276,7 +276,7 @@ SQUIRREL_API void sq_setreleasehook(HSQUIRRELVM v,SQInteger idx,SQRELEASEHOOK ho
 SQUIRREL_API SQRELEASEHOOK sq_getreleasehook(HSQUIRRELVM v,SQInteger idx);
 SQUIRREL_API SQChar *sq_getscratchpad(HSQUIRRELVM v,SQInteger minsize);
 SQUIRREL_API SQRESULT sq_getfunctioninfo(HSQUIRRELVM v,SQInteger level,SQFunctionInfo *fi);
-SQUIRREL_API SQRESULT sq_getclosureinfo(HSQUIRRELVM v,SQInteger idx,SQUnsignedInteger *nparams,SQUnsignedInteger *nfreevars);
+SQUIRREL_API SQRESULT sq_getclosureinfo(HSQUIRRELVM v,SQInteger idx,SQInteger *nparams,SQInteger *nfreevars);
 SQUIRREL_API SQRESULT sq_getclosurename(HSQUIRRELVM v,SQInteger idx);
 SQUIRREL_API SQRESULT sq_setnativeclosurename(HSQUIRRELVM v,SQInteger idx,const SQChar *name);
 SQUIRREL_API SQRESULT sq_setinstanceup(HSQUIRRELVM v, SQInteger idx, SQUserPointer p);

--- a/squirrel/sqapi.cpp
+++ b/squirrel/sqapi.cpp
@@ -394,21 +394,21 @@ void sq_newclosure(HSQUIRRELVM v,SQFUNCTION func,SQUnsignedInteger nfreevars)
     v->Push(SQObjectPtr(nc));
 }
 
-SQRESULT sq_getclosureinfo(HSQUIRRELVM v,SQInteger idx,SQUnsignedInteger *nparams,SQUnsignedInteger *nfreevars)
+SQRESULT sq_getclosureinfo(HSQUIRRELVM v,SQInteger idx,SQInteger *nparams,SQInteger *nfreevars)
 {
     SQObject o = stack_get(v, idx);
     if(sq_type(o) == OT_CLOSURE) {
         SQClosure *c = _closure(o);
         SQFunctionProto *proto = c->_function;
-        *nparams = (SQUnsignedInteger)proto->_nparameters;
-        *nfreevars = (SQUnsignedInteger)proto->_noutervalues;
+        *nparams = proto->_nparameters;
+        *nfreevars = proto->_noutervalues;
         return SQ_OK;
     }
     else if(sq_type(o) == OT_NATIVECLOSURE)
     {
         SQNativeClosure *c = _nativeclosure(o);
-        *nparams = (SQUnsignedInteger)c->_nparamscheck;
-        *nfreevars = c->_noutervalues;
+        *nparams = c->_nparamscheck;
+        *nfreevars = (SQInteger)c->_noutervalues;
         return SQ_OK;
     }
     return sq_throwerror(v,_SC("the object is not a closure"));


### PR DESCRIPTION
For native closures this method returns _nparamscheck value
which can be negative when function accepts variable number of
arguments - and it's incorrect to cast it to unsigned.

Also, _nparameters, _noutervalues and _nparamscheck fields are
actually signed integers, so it is better to keep them signed.
And casting _noutervalues is ok since it has enough capacity.