### PR TITLE
Raise an error on duplicate local variable name

### DIFF
--- a/squirrel/sqcompiler.cpp
+++ b/squirrel/sqcompiler.cpp
@@ -1005,6 +1005,11 @@ public:
             _fs->SetInstructionParam(tpos, 1, nkeys);
         Lex();
     }
+    void CheckDuplicateLocalVariable(const SQObject &name)
+    {
+        if (_fs->GetLocalVariable(name) >= 0)
+            Error(_SC("Local variable '%s' already exists"), _string(name)->_val);
+    }
     void LocalDeclStatement()
     {
         SQObject varname;
@@ -1012,6 +1017,7 @@ public:
         if( _token == TK_FUNCTION) {
             Lex();
             varname = Expect(TK_IDENTIFIER);
+            CheckDuplicateLocalVariable(varname);
             Expect(_SC('('));
             CreateFunction(varname,false);
             _fs->AddInstruction(_OP_CLOSURE, _fs->PushTarget(), _fs->_functions.size() - 1, 0);
@@ -1022,6 +1028,7 @@ public:
 
         do {
             varname = Expect(TK_IDENTIFIER);
+            CheckDuplicateLocalVariable(varname);
             if(_token == _SC('=')) {
                 Lex(); Expression();
                 SQInteger src = _fs->PopTarget();
@@ -1180,9 +1187,12 @@ public:
     {
         SQObject idxname, valname;
         Lex(); Expect(_SC('(')); valname = Expect(TK_IDENTIFIER);
+        CheckDuplicateLocalVariable(valname);
+
         if(_token == _SC(',')) {
             idxname = valname;
             Lex(); valname = Expect(TK_IDENTIFIER);
+            CheckDuplicateLocalVariable(valname);
         }
         else{
             idxname = _fs->CreateString(_SC("@INDEX@"));


### PR DESCRIPTION
Prevent local variable shadowing, deny redeclaring local variables with the same name in the same scope.
This includes function arguments, local variables and foreach iterators.
This is a breaking change - existing scripts can fail to compile now.
But making the language stricter is a good thing as it helps to avoid errors.

Example code (was sucessfully compiling earlier, but not now)

```
local function foo(player) {
  local player = get_local_player()
  foreach (id, player in enemies) {
    player.respawn()
  }
}
```

or simply

```
local a = 10
local x = "foo"
local a = "bar"
local nextA = a-1
```

It is better to detect such (potential) errors earlier, in compile time instead of runtime.