### PR TITLE
Duplicated call of releasehook was fixed.

### DIFF
--- a/squirrel/sqstate.cpp
+++ b/squirrel/sqstate.cpp
@@ -433,8 +433,8 @@ SQUnsignedInteger RefTable::GetRefCount(SQObject &obj)
 {
      SQHash mainpos;
      RefNode *prev;
-     RefNode *ref = Get(obj,mainpos,&prev,true);
-     return ref->refs;
+     RefNode *ref = Get(obj,mainpos,&prev,false);
+     return ref ? ref->refs : 0;
 }
 
 


### PR DESCRIPTION
It seems that GetRefCount method breaks read semantics. Since it will add reference to object in case it missing.
I have recived this problem when called this method after my native class was destructed .
Thi method added reference into RefTable and relase hoook was called second time => I'v got dupliucated delition of my object.
So it seems it shouldn't add reference during call