### PR TITLE
Fix 0x0x printout on gcc / clang

### DIFF
--- a/squirrel/sqfuncstate.cpp
+++ b/squirrel/sqfuncstate.cpp
@@ -82,7 +82,7 @@ void DumpLiteral(SQObjectPtr &o)
         case OT_FLOAT: scprintf(_SC("{%f}"),_float(o));break;
         case OT_INTEGER: scprintf(_SC("{") _PRINT_INT_FMT _SC("}"),_integer(o));break;
         case OT_BOOL: scprintf(_SC("%s"),_integer(o)?_SC("true"):_SC("false"));break;
-        default: scprintf(_SC("(%s %p)"),GetTypeName(o),(void*)_rawval(o));break; break; //shut up compiler
+        default: scprintf(_SC("(%s 0x%zx)"),GetTypeName(o),(size_t)_rawval(o));break; break; //shut up compiler
     }
 }
 

--- a/squirrel/sqvm.cpp
+++ b/squirrel/sqvm.cpp
@@ -313,7 +313,7 @@ bool SQVM::ToString(const SQObjectPtr &o,SQObjectPtr &res)
             }
         }
     default:
-        scsprintf(_sp(sq_rsl((sizeof(void*)*2)+NUMBER_MAX_CHAR)),sq_rsl((sizeof(void*)*2)+NUMBER_MAX_CHAR),_SC("(%s : 0x%p)"),GetTypeName(o),(void*)_rawval(o));
+        scsprintf(_sp(sq_rsl((sizeof(void*)*2)+NUMBER_MAX_CHAR)),sq_rsl((sizeof(void*)*2)+NUMBER_MAX_CHAR),_SC("(%s : 0x%zx)"),GetTypeName(o),(size_t)_rawval(o));
     }
     res = SQString::Create(_ss(this),_spval);
     return true;


### PR DESCRIPTION
> %p 
Is implementation-defined. GCC will print it as 0xffff.... while MSVC will print it as ffff.... This leads to `0x0xfffff` 

I replaced void* with size_t - it is C99 standard. 