### PR TITLE
Spelling fix in sqcompiler error

### DIFF
--- a/squirrel/sqcompiler.cpp
+++ b/squirrel/sqcompiler.cpp
@@ -635,7 +635,7 @@ public:
                 }
                 break;
             case _SC('['):
-                if(_lex._prevtoken == _SC('\n')) Error(_SC("cannot brake deref/or comma needed after [exp]=exp slot declaration"));
+                if(_lex._prevtoken == _SC('\n')) Error(_SC("cannot break deref/or comma needed after [exp]=exp slot declaration"));
                 Lex(); Expression(); Expect(_SC(']'));
                 pos = -1;
                 if(_es.etype==BASE) {


### PR DESCRIPTION
This error isn't as clear as it could be, but I think this would be break, not brake.