### PR TITLE
Set error message if called object is not callable

### DIFF
--- a/squirrel/sqvm.cpp
+++ b/squirrel/sqvm.cpp
@@ -1605,6 +1605,7 @@ SQInteger prevstackbase = _stackbase;
                    }
         break;
     default:
+        Raise_Error(_SC("attempt to call '%s'"), GetTypeName(closure));
         return false;
     }
 #ifdef _DEBUG


### PR DESCRIPTION
Report error if called object is not OT_CLOSURE, OT_NATIVECLOSURE nor OT_CLASS