### PR TITLE
fix compilation warning

### DIFF
--- a/squirrel/sqbaselib.cpp
+++ b/squirrel/sqbaselib.cpp
@@ -625,7 +625,7 @@ static SQInteger __map_array(SQArray *dest,SQArray *src,HSQUIRRELVM v) {
     SQObject &closure = stack_get(v, 2);
     v->Push(closure);
 
-    SQInteger nArgs;
+    SQInteger nArgs = 0;
     if(sq_type(closure) == OT_CLOSURE) {
         nArgs = _closure(closure)->_function->_nparameters;
     }


### PR DESCRIPTION
> albertodemichelis/squirrel/squirrel/sqbaselib.cpp: In function ‘SQInteger __map_array(SQArray*, SQArray*, HSQUIRRELVM)’:
> albertodemichelis/squirrel/squirrel/sqbaselib.cpp:646:9: warning: ‘nArgs’ may be used uninitialized in this function [-Wmaybe-uninitialized]
>         if (nArgs >= 4)
>         ^

fixes #205