### PR TITLE
Set format string for _string_printf

### DIFF
--- a/sqstdlib/sqstdstring.cpp
+++ b/sqstdlib/sqstdstring.cpp
@@ -181,7 +181,7 @@ static SQInteger _string_printf(HSQUIRRELVM v)
         return -1;
 
     SQPRINTFUNCTION printfunc = sq_getprintfunc(v);
-    if(printfunc) printfunc(v,dest);
+    if(printfunc) printfunc(v,_SC("%s"),dest);
 
     return 0;
 }


### PR DESCRIPTION
In current implementation string "dest" is used as "format string" in call to "printfunc".
This leads to unpredictable behavior if something like format string is produced by "sqstd_format".
For example string "%%*s" once formated results in "%*s", passed to "printfunc" will try to read two integer arguments (which are not given).

Quick test:
sq>printf("%%*s")
%*s
