### PR TITLE
Fix creating unnecessary temporary object with refcount

### DIFF
--- a/squirrel/sqtable.h
+++ b/squirrel/sqtable.h
@@ -12,7 +12,7 @@
 
 #define hashptr(p)  ((SQHash)(((SQInteger)p) >> 3))
 
-inline SQHash HashObj(const SQObjectPtr &key)
+inline SQHash HashObj(const SQObject &key)
 {
     switch(sq_type(key)) {
         case OT_STRING:     return _string(key)->_hash;


### PR DESCRIPTION
Using the SQObject& is enough for HashObj() function.

In the following code

```
  RefTable::RefNode *RefTable::Get(SQObject &obj,SQHash &mainpos,RefNode **prev,bool add)
  {
    RefNode *ref;
    mainpos = ::HashObj(obj)&(_numofslots-1);
```

obj was an SQObject and because HashObj() accepted SQObjectPtr&, a temporary SQObjectPtr was created and refcounting was performed, which only lead to unnecessary overhead.