### PR TITLE
Integer overflow crash fix

### DIFF
--- a/squirrel/sqvm.cpp
+++ b/squirrel/sqvm.cpp
@@ -50,11 +50,14 @@ bool SQVM::BW_OP(SQUnsignedInteger op,SQObjectPtr &trg,const SQObjectPtr &o1,con
     } \
 }
 
-#define _ARITH_NOZERO(op,trg,o1,o2,err) \
+#define _ARITH_NOZERO(op,trg,o1,o2) \
 { \
     SQInteger tmask = sq_type(o1)|sq_type(o2); \
     switch(tmask) { \
-        case OT_INTEGER: { SQInteger i2 = _integer(o2); if(i2 == 0) { Raise_Error(err); SQ_THROW(); } trg = _integer(o1) op i2; } break;\
+        case OT_INTEGER: { SQInteger i2 = _integer(o2); \
+            if(i2 == 0) { Raise_Error(_SC("division by zero")); SQ_THROW(); } \
+            else if (i2 == -1 && _integer(o1) == INT_MIN) { Raise_Error(_SC("integer overflow")); SQ_THROW(); } \
+            trg = _integer(o1) op i2; } break; \
         case (OT_FLOAT|OT_INTEGER): \
         case (OT_FLOAT): trg = tofloat(o1) op tofloat(o2); break;\
         default: _GUARD(ARITH_OP((#op)[0],trg,o1,o2)); break;\
@@ -858,7 +861,7 @@ exception_restore:
             case _OP_ADD: _ARITH_(+,TARGET,STK(arg2),STK(arg1)); continue;
             case _OP_SUB: _ARITH_(-,TARGET,STK(arg2),STK(arg1)); continue;
             case _OP_MUL: _ARITH_(*,TARGET,STK(arg2),STK(arg1)); continue;
-            case _OP_DIV: _ARITH_NOZERO(/,TARGET,STK(arg2),STK(arg1),_SC("division by zero")); continue;
+            case _OP_DIV: _ARITH_NOZERO(/,TARGET,STK(arg2),STK(arg1)); continue;
             case _OP_MOD: ARITH_OP('%',TARGET,STK(arg2),STK(arg1)); continue;
             case _OP_BITW:  _GUARD(BW_OP( arg3,TARGET,STK(arg2),STK(arg1))); continue;
             case _OP_RETURN:


### PR DESCRIPTION
Replicate crash:

```cpp
(-0x7FFFFFFF-1) / -1
```

squirrel 3.0 stable added `INT_MIN / -1` integer overflow check inside `SQVM::ARITH_OP`. However this is never checked because the `_OP_DIV` instruction executes the `_ARITH_NOZERO` macro, which only has division by zero check.

This PR adds the check from `SQVM::ARITH_OP` into `_ARITH_NOZERO`. I have decided not to create the `i1` local variable because the only time `_integer(o1)` is accessed twice is the rare case of `i2 == -1`.