### PR TITLE
Fix interpreter CMake alias for static builds

### DIFF
--- a/sq/CMakeLists.txt
+++ b/sq/CMakeLists.txt
@@ -15,7 +15,7 @@ endif()
 
 if(NOT DISABLE_STATIC)
   add_executable(sq_static sq.c)
-  add_executable(squirrel::interpreter_static ALIAS sq)
+  add_executable(squirrel::interpreter_static ALIAS sq_static)
   set_target_properties(sq_static PROPERTIES LINKER_LANGUAGE C EXPORT_NAME interpreter_static)
   target_link_libraries(sq_static squirrel_static sqstdlib_static)
   if(NOT SQ_DISABLE_INSTALLER)


### PR DESCRIPTION
Attempting to build Squirrel with CMake and `-DDISABLE_DYNAMIC=ON` will fail.

The reason seems to be a mistake: in `sq/CMakeLists.txt`, at line 18, the alias generated for `squirrel::interpreter_static` is actually an alias for the dynamically-linked `sq` instead of `sq_static`.

Since the code for static builds is the same as the code for dynamic builds but with "_static" appended to all names, I assumed it was a simple omission and changed `sq` to `sq_static`, which fixed the problem.