### PR TITLE
Move CMake installer line in if() statement

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,12 +87,12 @@ configure_package_config_file(
   INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/squirrel"
   )
 
-export(EXPORT squirrel
-  NAMESPACE squirrel::
-  FILE "${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}/cmake/squirrel/squirrel-targets.cmake"
-  )
-
 if(NOT SQ_DISABLE_INSTALLER AND NOT SQ_DISABLE_CMAKE_INSTALLER)
+  export(EXPORT squirrel
+    NAMESPACE squirrel::
+    FILE "${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}/cmake/squirrel/squirrel-targets.cmake"
+    )
+
   install(FILES
     "${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}/cmake/squirrel/squirrel-config-version.cmake"
     "${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}/cmake/squirrel/squirrel-config.cmake"


### PR DESCRIPTION
Fixes #243 

There is a line in CMakeLists.txt which prevents builds with `SQ_DISABLE_INSTALLER` from working properly. It seems to be a line that should be guarded by `if(NOT SQ_DISABLE_INSTALLER AND NOT SQ_DISABLE_CMAKE_INSTALLER)`, so I moved it inside the block.