### PR TITLE
Enabling static access with the _get meta method.

### DIFF
--- a/squirrel/sqclass.cpp
+++ b/squirrel/sqclass.cpp
@@ -146,6 +146,15 @@ bool SQClass::GetAttributes(const SQObjectPtr &key,SQObjectPtr &outval)
     return false;
 }
 
+bool SQClass::GetMetaMethod(SQVM* SQ_UNUSED_ARG(v), SQMetaMethod mm, SQObjectPtr& res)
+{
+    if (sq_type(_metamethods[mm]) != OT_NULL) {
+        res = _metamethods[mm];
+        return true;
+    }
+    return false;
+}
+
 ///////////////////////////////////////////////////////////////////////
 void SQInstance::Init(SQSharedState *ss)
 {

--- a/squirrel/sqclass.h
+++ b/squirrel/sqclass.h
@@ -72,6 +72,7 @@ public:
 #endif
     SQInteger Next(const SQObjectPtr &refpos, SQObjectPtr &outkey, SQObjectPtr &outval);
     SQInstance *CreateInstance();
+    bool GetMetaMethod(SQVM* v, SQMetaMethod mm, SQObjectPtr& res);
     SQTable *_members;
     SQClass *_base;
     SQClassMemberVec _defaultvalues;

--- a/squirrel/sqvm.cpp
+++ b/squirrel/sqvm.cpp
@@ -1379,6 +1379,7 @@ SQInteger SQVM::FallBackGet(const SQObjectPtr &self,const SQObjectPtr &key,SQObj
             }
         }
                       }
+        break;
     default: break;//shutup GCC 4.x
     }
     // no metamethod or no fallback type

--- a/squirrel/sqvm.cpp
+++ b/squirrel/sqvm.cpp
@@ -1361,6 +1361,24 @@ SQInteger SQVM::FallBackGet(const SQObjectPtr &self,const SQObjectPtr &key,SQObj
         }
                       }
         break;
+    case OT_CLASS: {
+        SQObjectPtr closure;
+        if (_class(self)->GetMetaMethod(this, MT_GET, closure)) {
+            Push(self); Push(key);
+            _nmetamethodscall++;
+            AutoDec ad(&_nmetamethodscall);
+            if (Call(closure, 2, _top - 2, dest, SQFalse)) {
+                Pop(2);
+                return FALLBACK_OK;
+            }
+            else {
+                Pop(2);
+                if (sq_type(_lasterror) != OT_NULL) { //NULL means "clean failure" (not found)
+                    return FALLBACK_ERROR;
+                }
+            }
+        }
+                      }
     default: break;//shutup GCC 4.x
     }
     // no metamethod or no fallback type


### PR DESCRIPTION
I would like to be able to implement the following to support C# and C++ static variable bindings.
```
class StaticGetSample
{
    function _get(key)
    {
        switch (key)
        {
            case "foo":
                return "a";
            case "bar":
                return "b";
        }
        return null;
    }
}

// output `a`.
print(StaticGetSample.foo);
```

Meta method call of SQClass was implemented with reference to the implementation of SQInstance.