### PR TITLE
Fix iOS detection

### DIFF
--- a/sqstdlib/sqstdsystem.cpp
+++ b/sqstdlib/sqstdsystem.cpp
@@ -5,6 +5,13 @@
 #include <stdio.h>
 #include <sqstdsystem.h>
 
+#if defined(__APPLE__) && !defined(IOS)
+#include <TargetConditionals.h>
+#if TARGET_OS_IPHONE
+#define IOS
+#endif
+#endif
+
 #ifdef SQUNICODE
 #include <wchar.h>
 #define scgetenv _wgetenv


### PR DESCRIPTION
IOS macro is not automatically defined when compiling to iOS devices.

The reliable way to detect iOS is to detect `__APPLE__`, include <TargetConditionals.h> and then check for TARGET_OS_IPHONE.

See https://stackoverflow.com/questions/5919996/how-to-detect-reliably-mac-os-x-ios-linux-windows-in-c-preprocessor and https://gist.github.com/TatsuyaOGth/7a6006c9ddecbc3fb655