### PR TITLE
Checking for minimum/maximum number of native closure parameters

### DIFF
--- a/doc/source/reference/api/object_creation_and_handling.rst
+++ b/doc/source/reference/api/object_creation_and_handling.rst
@@ -66,11 +66,12 @@ pushes the value of a class or instance member using a member handle (see sq_get
 
 .. _sq_getclosureinfo:
 
-.. c:function:: SQRESULT sq_getclosureinfo(HSQUIRRELVM v, SQInteger idx, SQInteger * nparams, SQInteger * nfreevars)
+.. c:function:: SQRESULT sq_getclosureinfo(HSQUIRRELVM v, SQInteger idx, SQInteger * nparamsmin, SQInteger * nparamsmax, SQInteger * nfreevars)
 
     :param HSQUIRRELVM v: the target VM
     :param SQInteger idx: index of the target closure
-    :param SQInteger * nparams: a pointer to an integer that will store the number of parameters
+    :param SQInteger * nparamsmin: a pointer to an integer that will store the minimum required number of parameters (for non-native closures this is equal to 'nparamsmax')
+    :param SQInteger * nparamsmax: a pointer to an integer that will store the maximum allowed number of parameters (for non-native closures this is equal to 'nparamsmin')
     :param SQInteger * nfreevars: a pointer to an integer that will store the number of free variables
     :returns: an SQRESULT
 
@@ -569,12 +570,13 @@ sets the name of the native closure at the position idx in the stack. The name o
 
 .. _sq_setparamscheck:
 
-.. c:function:: SQRESULT sq_setparamscheck(HSQUIRRELVM v, SQInteger nparamscheck, const SQChar * typemask)
+.. c:function:: SQRESULT sq_setparamscheck(HSQUIRRELVM v, SQInteger nparamscheckmin, SQInteger nparamscheckmax, const SQChar * typemask)
 
     :param HSQUIRRELVM v: the target VM
-    :param SQInteger nparamscheck: defines the parameters number check policy (0 disables the param checking). If nparamscheck is greater than 0, the VM ensures that the number of parameters is exactly the number specified in nparamscheck (eg. if nparamscheck == 3 the function can only be called with 3 parameters). If nparamscheck is less than 0 the VM ensures that the closure is called with at least the absolute value of the number specified in nparamcheck (eg. nparamscheck == -3 will check that the function is called with at least 3 parameters). The hidden parameter 'this' is included in this number; free variables aren't. If SQ_MATCHTYPEMASKSTRING is passed instead of the number of parameters, the function will automatically infer the number of parameters to check from the typemask (eg. if the typemask is ".sn", it is like passing 3).
+    :param SQInteger nparamscheckmin: defines the minimum for the parameters number check policy (0 or negative disables the minimum parameters checking). The hidden parameter 'this' is included in this number; free variables aren't. If SQ_MATCHTYPEMASKSTRING is passed instead of the number of parameters, the function will automatically infer the number of minimum parameters to check from the typemask (eg. if the typemask is ".sn", it is like passing 3).
+    :param SQInteger nparamscheckmax: defines the maximum for the parameters number check policy (0 or negative disables the maximum parameters checking). The hidden parameter 'this' is included in this number; free variables aren't. If SQ_MATCHTYPEMASKSTRING is passed instead of the number of parameters, the function will automatically infer the number of maximum parameters to check from the typemask (eg. if the typemask is ".sn", it is like passing 3).
     :param SQChar * typemask: defines a mask to validate the parametes types passed to the function. If the parameter is NULL, no typechecking is applied (default).
-    :remarks: The typemask consists in a zero terminated string that represent the expected parameter type. The types are expressed as follows: 'o' null, 'i' integer, 'f' float, 'n' integer or float, 's' string, 't' table, 'a' array, 'u' userdata, 'c' closure and nativeclosure, 'g' generator, 'p' userpointer, 'v' thread, 'x' instance(class instance), 'y' class, 'b' bool. and '.' any type. The symbol '|' can be used as 'or' to accept multiple types on the same parameter. There isn't any limit on the number of 'or' that can be used. Spaces are ignored so can be inserted between types to increase readability. For instance to check a function that expect a table as 'this' a string as first parameter and a number or a userpointer as second parameter, the string would be "tsn|p" (table,string,number or userpointer). If the parameters mask is contains fewer parameters than 'nparamscheck', the remaining parameters will not be typechecked.
+    :remarks: The typemask consists in a zero terminated string that represent the expected parameter type. The types are expressed as follows: 'o' null, 'i' integer, 'f' float, 'n' integer or float, 's' string, 't' table, 'a' array, 'u' userdata, 'c' closure and nativeclosure, 'g' generator, 'p' userpointer, 'v' thread, 'x' instance(class instance), 'y' class, 'b' bool. and '.' any type. The symbol '|' can be used as 'or' to accept multiple types on the same parameter. There isn't any limit on the number of 'or' that can be used. Spaces are ignored so can be inserted between types to increase readability. For instance to check a function that expect a table as 'this' a string as first parameter and a number or a userpointer as second parameter, the string would be "tsn|p" (table,string,number or userpointer). If the parameters mask contains fewer parameters than 'nparamscheckmax', the remaining parameters will not be typechecked.
 
 Sets the parameter validation scheme for the native closure at the top position in the stack. Allows you to validate the number of parameters accepted by the function and optionally their types. If the function call does not comply with the parameter schema set by sq_setparamscheck, an exception is thrown.
 
@@ -602,7 +604,11 @@ Sets the parameter validation scheme for the native closure at the top position 
     //....stuff
     sq_newclosure(v,testy,0);
     //expects exactly 3 parameters(userdata,string,number)
-    sq_setparamscheck(v,3,_SC("usn"));
+    sq_setparamscheck(v,3,3,_SC("usn"));
+    //expects at least 2 parameters(userdata,string)
+    sq_setparamscheck(v,2,0,_SC("usnsb"));
+    //expects 1 to 3 parameters(userdata,string,number)
+    sq_setparamscheck(v,1,3,_SC("usn"));
     //....stuff
 
 

--- a/include/squirrel.h
+++ b/include/squirrel.h
@@ -187,7 +187,8 @@ typedef SQInteger (*SQLEXREADFUNC)(SQUserPointer);
 typedef struct tagSQRegFunction{
     const SQChar *name;
     SQFUNCTION f;
-    SQInteger nparamscheck;
+    SQInteger nparamscheckmin;
+    SQInteger nparamscheckmax;
     const SQChar *typemask;
 }SQRegFunction;
 
@@ -243,7 +244,7 @@ SQUIRREL_API void sq_newtable(HSQUIRRELVM v);
 SQUIRREL_API void sq_newtableex(HSQUIRRELVM v,SQInteger initialcapacity);
 SQUIRREL_API void sq_newarray(HSQUIRRELVM v,SQInteger size);
 SQUIRREL_API void sq_newclosure(HSQUIRRELVM v,SQFUNCTION func,SQUnsignedInteger nfreevars);
-SQUIRREL_API SQRESULT sq_setparamscheck(HSQUIRRELVM v,SQInteger nparamscheck,const SQChar *typemask);
+SQUIRREL_API SQRESULT sq_setparamscheck(HSQUIRRELVM v,SQInteger nparamscheckmin,SQInteger nparamscheckmax,const SQChar *typemask);
 SQUIRREL_API SQRESULT sq_bindenv(HSQUIRRELVM v,SQInteger idx);
 SQUIRREL_API SQRESULT sq_setclosureroot(HSQUIRRELVM v,SQInteger idx);
 SQUIRREL_API SQRESULT sq_getclosureroot(HSQUIRRELVM v,SQInteger idx);
@@ -276,7 +277,7 @@ SQUIRREL_API void sq_setreleasehook(HSQUIRRELVM v,SQInteger idx,SQRELEASEHOOK ho
 SQUIRREL_API SQRELEASEHOOK sq_getreleasehook(HSQUIRRELVM v,SQInteger idx);
 SQUIRREL_API SQChar *sq_getscratchpad(HSQUIRRELVM v,SQInteger minsize);
 SQUIRREL_API SQRESULT sq_getfunctioninfo(HSQUIRRELVM v,SQInteger level,SQFunctionInfo *fi);
-SQUIRREL_API SQRESULT sq_getclosureinfo(HSQUIRRELVM v,SQInteger idx,SQInteger *nparams,SQInteger *nfreevars);
+SQUIRREL_API SQRESULT sq_getclosureinfo(HSQUIRRELVM v,SQInteger idx,SQInteger *nparamsmin,SQInteger *nparamsmax,SQInteger *nfreevars);
 SQUIRREL_API SQRESULT sq_getclosurename(HSQUIRRELVM v,SQInteger idx);
 SQUIRREL_API SQRESULT sq_setnativeclosurename(HSQUIRRELVM v,SQInteger idx,const SQChar *name);
 SQUIRREL_API SQRESULT sq_setinstanceup(HSQUIRRELVM v, SQInteger idx, SQUserPointer p);

--- a/sq/sq.c
+++ b/sq/sq.c
@@ -236,7 +236,7 @@ void Interactive(HSQUIRRELVM v)
     sq_pushstring(v,_SC("quit"),-1);
     sq_pushuserpointer(v,&done);
     sq_newclosure(v,quit,1);
-    sq_setparamscheck(v,1,NULL);
+    sq_setparamscheck(v,1,1,NULL);
     sq_newslot(v,-3,SQFalse);
     sq_pop(v,1);
 

--- a/sqstdlib/sqstdblob.cpp
+++ b/sqstdlib/sqstdblob.cpp
@@ -167,18 +167,18 @@ static SQInteger _blob__cloned(HSQUIRRELVM v)
     return 0;
 }
 
-#define _DECL_BLOB_FUNC(name,nparams,typecheck) {_SC(#name),_blob_##name,nparams,typecheck}
+#define _DECL_BLOB_FUNC(name,nparamsmin,nparamsmax,typecheck) {_SC(#name),_blob_##name,nparamsmin,nparamsmax,typecheck}
 static const SQRegFunction _blob_methods[] = {
-    _DECL_BLOB_FUNC(constructor,-1,_SC("xn")),
-    _DECL_BLOB_FUNC(resize,2,_SC("xn")),
-    _DECL_BLOB_FUNC(swap2,1,_SC("x")),
-    _DECL_BLOB_FUNC(swap4,1,_SC("x")),
-    _DECL_BLOB_FUNC(_set,3,_SC("xnn")),
-    _DECL_BLOB_FUNC(_get,2,_SC("x.")),
-    _DECL_BLOB_FUNC(_typeof,1,_SC("x")),
-    _DECL_BLOB_FUNC(_nexti,2,_SC("x")),
-    _DECL_BLOB_FUNC(_cloned,2,_SC("xx")),
-    {NULL,(SQFUNCTION)0,0,NULL}
+    _DECL_BLOB_FUNC(constructor,1,0,_SC("xn")),
+    _DECL_BLOB_FUNC(resize,2,2,_SC("xn")),
+    _DECL_BLOB_FUNC(swap2,1,1,_SC("x")),
+    _DECL_BLOB_FUNC(swap4,1,1,_SC("x")),
+    _DECL_BLOB_FUNC(_set,3,3,_SC("xnn")),
+    _DECL_BLOB_FUNC(_get,2,2,_SC("x.")),
+    _DECL_BLOB_FUNC(_typeof,1,1,_SC("x")),
+    _DECL_BLOB_FUNC(_nexti,2,2,_SC("x")),
+    _DECL_BLOB_FUNC(_cloned,2,2,_SC("xx")),
+    {NULL,(SQFUNCTION)0,0,0,NULL}
 };
 
 
@@ -229,14 +229,14 @@ static SQInteger _g_blob_swapfloat(HSQUIRRELVM v)
     return 1;
 }
 
-#define _DECL_GLOBALBLOB_FUNC(name,nparams,typecheck) {_SC(#name),_g_blob_##name,nparams,typecheck}
+#define _DECL_GLOBALBLOB_FUNC(name,nparamsmin,nparamsmax,typecheck) {_SC(#name),_g_blob_##name,nparamsmin,nparamsmax,typecheck}
 static const SQRegFunction bloblib_funcs[]={
-    _DECL_GLOBALBLOB_FUNC(casti2f,2,_SC(".n")),
-    _DECL_GLOBALBLOB_FUNC(castf2i,2,_SC(".n")),
-    _DECL_GLOBALBLOB_FUNC(swap2,2,_SC(".n")),
-    _DECL_GLOBALBLOB_FUNC(swap4,2,_SC(".n")),
-    _DECL_GLOBALBLOB_FUNC(swapfloat,2,_SC(".n")),
-    {NULL,(SQFUNCTION)0,0,NULL}
+    _DECL_GLOBALBLOB_FUNC(casti2f,2,2,_SC(".n")),
+    _DECL_GLOBALBLOB_FUNC(castf2i,2,2,_SC(".n")),
+    _DECL_GLOBALBLOB_FUNC(swap2,2,2,_SC(".n")),
+    _DECL_GLOBALBLOB_FUNC(swap4,2,2,_SC(".n")),
+    _DECL_GLOBALBLOB_FUNC(swapfloat,2,2,_SC(".n")),
+    {NULL,(SQFUNCTION)0,0,0,NULL}
 };
 
 SQRESULT sqstd_getblob(HSQUIRRELVM v,SQInteger idx,SQUserPointer *ptr)

--- a/sqstdlib/sqstdio.cpp
+++ b/sqstdlib/sqstdio.cpp
@@ -163,12 +163,12 @@ static SQInteger _file_close(HSQUIRRELVM v)
 }
 
 //bindings
-#define _DECL_FILE_FUNC(name,nparams,typecheck) {_SC(#name),_file_##name,nparams,typecheck}
+#define _DECL_FILE_FUNC(name,nparamsmin,nparamsmax,typecheck) {_SC(#name),_file_##name,nparamsmin,nparamsmax,typecheck}
 static const SQRegFunction _file_methods[] = {
-    _DECL_FILE_FUNC(constructor,3,_SC("x")),
-    _DECL_FILE_FUNC(_typeof,1,_SC("x")),
-    _DECL_FILE_FUNC(close,1,_SC("x")),
-    {NULL,(SQFUNCTION)0,0,NULL}
+    _DECL_FILE_FUNC(constructor,3,3,_SC("x")),
+    _DECL_FILE_FUNC(_typeof,1,1,_SC("x")),
+    _DECL_FILE_FUNC(close,1,1,_SC("x")),
+    {NULL,(SQFUNCTION)0,0,0,NULL}
 };
 
 
@@ -462,12 +462,12 @@ SQInteger _g_io_dofile(HSQUIRRELVM v)
     return SQ_ERROR; //propagates the error
 }
 
-#define _DECL_GLOBALIO_FUNC(name,nparams,typecheck) {_SC(#name),_g_io_##name,nparams,typecheck}
+#define _DECL_GLOBALIO_FUNC(name,nparamsmin,nparamsmax,typecheck) {_SC(#name),_g_io_##name,nparamsmin,nparamsmax,typecheck}
 static const SQRegFunction iolib_funcs[]={
-    _DECL_GLOBALIO_FUNC(loadfile,-2,_SC(".sb")),
-    _DECL_GLOBALIO_FUNC(dofile,-2,_SC(".sb")),
-    _DECL_GLOBALIO_FUNC(writeclosuretofile,3,_SC(".sc")),
-    {NULL,(SQFUNCTION)0,0,NULL}
+    _DECL_GLOBALIO_FUNC(loadfile,2,0,_SC(".sb")),
+    _DECL_GLOBALIO_FUNC(dofile,2,0,_SC(".sb")),
+    _DECL_GLOBALIO_FUNC(writeclosuretofile,3,3,_SC(".sc")),
+    {NULL,(SQFUNCTION)0,0,0,NULL}
 };
 
 SQRESULT sqstd_register_iolib(HSQUIRRELVM v)

--- a/sqstdlib/sqstdmath.cpp
+++ b/sqstdlib/sqstdmath.cpp
@@ -58,27 +58,27 @@ SINGLE_ARG_FUNC(floor)
 SINGLE_ARG_FUNC(ceil)
 SINGLE_ARG_FUNC(exp)
 
-#define _DECL_FUNC(name,nparams,tycheck) {_SC(#name),math_##name,nparams,tycheck}
+#define _DECL_FUNC(name,nparamsmin,nparamsmax,tycheck) {_SC(#name),math_##name,nparamsmin,nparamsmax,tycheck}
 static const SQRegFunction mathlib_funcs[] = {
-    _DECL_FUNC(sqrt,2,_SC(".n")),
-    _DECL_FUNC(sin,2,_SC(".n")),
-    _DECL_FUNC(cos,2,_SC(".n")),
-    _DECL_FUNC(asin,2,_SC(".n")),
-    _DECL_FUNC(acos,2,_SC(".n")),
-    _DECL_FUNC(log,2,_SC(".n")),
-    _DECL_FUNC(log10,2,_SC(".n")),
-    _DECL_FUNC(tan,2,_SC(".n")),
-    _DECL_FUNC(atan,2,_SC(".n")),
-    _DECL_FUNC(atan2,3,_SC(".nn")),
-    _DECL_FUNC(pow,3,_SC(".nn")),
-    _DECL_FUNC(floor,2,_SC(".n")),
-    _DECL_FUNC(ceil,2,_SC(".n")),
-    _DECL_FUNC(exp,2,_SC(".n")),
-    _DECL_FUNC(srand,2,_SC(".n")),
-    _DECL_FUNC(rand,1,NULL),
-    _DECL_FUNC(fabs,2,_SC(".n")),
-    _DECL_FUNC(abs,2,_SC(".n")),
-    {NULL,(SQFUNCTION)0,0,NULL}
+    _DECL_FUNC(sqrt,2,2,_SC(".n")),
+    _DECL_FUNC(sin,2,2,_SC(".n")),
+    _DECL_FUNC(cos,2,2,_SC(".n")),
+    _DECL_FUNC(asin,2,2,_SC(".n")),
+    _DECL_FUNC(acos,2,2,_SC(".n")),
+    _DECL_FUNC(log,2,2,_SC(".n")),
+    _DECL_FUNC(log10,2,2,_SC(".n")),
+    _DECL_FUNC(tan,2,2,_SC(".n")),
+    _DECL_FUNC(atan,2,2,_SC(".n")),
+    _DECL_FUNC(atan2,3,3,_SC(".nn")),
+    _DECL_FUNC(pow,3,3,_SC(".nn")),
+    _DECL_FUNC(floor,2,2,_SC(".n")),
+    _DECL_FUNC(ceil,2,2,_SC(".n")),
+    _DECL_FUNC(exp,2,2,_SC(".n")),
+    _DECL_FUNC(srand,2,2,_SC(".n")),
+    _DECL_FUNC(rand,1,1,NULL),
+    _DECL_FUNC(fabs,2,2,_SC(".n")),
+    _DECL_FUNC(abs,2,2,_SC(".n")),
+    {NULL,(SQFUNCTION)0,0,0,NULL}
 };
 #undef _DECL_FUNC
 
@@ -92,7 +92,7 @@ SQRESULT sqstd_register_mathlib(HSQUIRRELVM v)
     while(mathlib_funcs[i].name!=0) {
         sq_pushstring(v,mathlib_funcs[i].name,-1);
         sq_newclosure(v,mathlib_funcs[i].f,0);
-        sq_setparamscheck(v,mathlib_funcs[i].nparamscheck,mathlib_funcs[i].typemask);
+        sq_setparamscheck(v,mathlib_funcs[i].nparamscheckmin,mathlib_funcs[i].nparamscheckmax,mathlib_funcs[i].typemask);
         sq_setnativeclosurename(v,-1,mathlib_funcs[i].name);
         sq_newslot(v,-3,SQFalse);
         i++;

--- a/sqstdlib/sqstdstream.cpp
+++ b/sqstdlib/sqstdstream.cpp
@@ -239,17 +239,17 @@ SQInteger _stream_eos(HSQUIRRELVM v)
  }
 
 static const SQRegFunction _stream_methods[] = {
-    _DECL_STREAM_FUNC(readblob,2,_SC("xn")),
-    _DECL_STREAM_FUNC(readn,2,_SC("xn")),
-    _DECL_STREAM_FUNC(writeblob,-2,_SC("xx")),
-    _DECL_STREAM_FUNC(writen,3,_SC("xnn")),
-    _DECL_STREAM_FUNC(seek,-2,_SC("xnn")),
-    _DECL_STREAM_FUNC(tell,1,_SC("x")),
-    _DECL_STREAM_FUNC(len,1,_SC("x")),
-    _DECL_STREAM_FUNC(eos,1,_SC("x")),
-    _DECL_STREAM_FUNC(flush,1,_SC("x")),
-    _DECL_STREAM_FUNC(_cloned,0,NULL),
-    {NULL,(SQFUNCTION)0,0,NULL}
+    _DECL_STREAM_FUNC(readblob,2,2,_SC("xn")),
+    _DECL_STREAM_FUNC(readn,2,2,_SC("xn")),
+    _DECL_STREAM_FUNC(writeblob,2,0,_SC("xx")),
+    _DECL_STREAM_FUNC(writen,3,3,_SC("xnn")),
+    _DECL_STREAM_FUNC(seek,2,0,_SC("xnn")),
+    _DECL_STREAM_FUNC(tell,1,1,_SC("x")),
+    _DECL_STREAM_FUNC(len,1,1,_SC("x")),
+    _DECL_STREAM_FUNC(eos,1,1,_SC("x")),
+    _DECL_STREAM_FUNC(flush,1,1,_SC("x")),
+    _DECL_STREAM_FUNC(_cloned,0,0,NULL),
+    {NULL,(SQFUNCTION)0,0,0,NULL}
 };
 
 void init_streamclass(HSQUIRRELVM v)
@@ -265,7 +265,7 @@ void init_streamclass(HSQUIRRELVM v)
             const SQRegFunction &f = _stream_methods[i];
             sq_pushstring(v,f.name,-1);
             sq_newclosure(v,f.f,0);
-            sq_setparamscheck(v,f.nparamscheck,f.typemask);
+            sq_setparamscheck(v,f.nparamscheckmin,f.nparamscheckmax,f.typemask);
             sq_newslot(v,-3,SQFalse);
             i++;
         }
@@ -301,7 +301,7 @@ SQRESULT declare_stream(HSQUIRRELVM v,const SQChar* name,SQUserPointer typetag,c
             const SQRegFunction &f = methods[i];
             sq_pushstring(v,f.name,-1);
             sq_newclosure(v,f.f,0);
-            sq_setparamscheck(v,f.nparamscheck,f.typemask);
+            sq_setparamscheck(v,f.nparamscheckmin,f.nparamscheckmax,f.typemask);
             sq_setnativeclosurename(v,-1,f.name);
             sq_newslot(v,-3,SQFalse);
             i++;
@@ -315,7 +315,7 @@ SQRESULT declare_stream(HSQUIRRELVM v,const SQChar* name,SQUserPointer typetag,c
             const SQRegFunction &f = globals[i];
             sq_pushstring(v,f.name,-1);
             sq_newclosure(v,f.f,0);
-            sq_setparamscheck(v,f.nparamscheck,f.typemask);
+            sq_setparamscheck(v,f.nparamscheckmin,f.nparamscheckmax,f.typemask);
             sq_setnativeclosurename(v,-1,f.name);
             sq_newslot(v,-3,SQFalse);
             i++;

--- a/sqstdlib/sqstdstream.h
+++ b/sqstdlib/sqstdstream.h
@@ -13,6 +13,6 @@ SQInteger _stream_len(HSQUIRRELVM v);
 SQInteger _stream_eos(HSQUIRRELVM v);
 SQInteger _stream_flush(HSQUIRRELVM v);
 
-#define _DECL_STREAM_FUNC(name,nparams,typecheck) {_SC(#name),_stream_##name,nparams,typecheck}
+#define _DECL_STREAM_FUNC(name,nparamsmin,nparamsmax,typecheck) {_SC(#name),_stream_##name,nparamsmin,nparamsmax,typecheck}
 SQRESULT declare_stream(HSQUIRRELVM v,const SQChar* name,SQUserPointer typetag,const SQChar* reg_name,const SQRegFunction *methods,const SQRegFunction *globals);
 #endif /*_SQSTD_STREAM_H_*/

--- a/sqstdlib/sqstdstring.cpp
+++ b/sqstdlib/sqstdstring.cpp
@@ -492,30 +492,30 @@ static SQInteger _regexp__typeof(HSQUIRRELVM v)
     return 1;
 }
 
-#define _DECL_REX_FUNC(name,nparams,pmask) {_SC(#name),_regexp_##name,nparams,pmask}
+#define _DECL_REX_FUNC(name,nparamsmin,nparamsmax,pmask) {_SC(#name),_regexp_##name,nparamsmin,nparamsmax,pmask}
 static const SQRegFunction rexobj_funcs[]={
-    _DECL_REX_FUNC(constructor,2,_SC(".s")),
-    _DECL_REX_FUNC(search,-2,_SC("xsn")),
-    _DECL_REX_FUNC(match,2,_SC("xs")),
-    _DECL_REX_FUNC(capture,-2,_SC("xsn")),
-    _DECL_REX_FUNC(subexpcount,1,_SC("x")),
-    _DECL_REX_FUNC(_typeof,1,_SC("x")),
-    {NULL,(SQFUNCTION)0,0,NULL}
+    _DECL_REX_FUNC(constructor,2,2,_SC(".s")),
+    _DECL_REX_FUNC(search,2,0,_SC("xsn")),
+    _DECL_REX_FUNC(match,2,2,_SC("xs")),
+    _DECL_REX_FUNC(capture,2,0,_SC("xsn")),
+    _DECL_REX_FUNC(subexpcount,1,1,_SC("x")),
+    _DECL_REX_FUNC(_typeof,1,1,_SC("x")),
+    {NULL,(SQFUNCTION)0,0,0,NULL}
 };
 #undef _DECL_REX_FUNC
 
-#define _DECL_FUNC(name,nparams,pmask) {_SC(#name),_string_##name,nparams,pmask}
+#define _DECL_FUNC(name,nparamsmin,nparamsmax,pmask) {_SC(#name),_string_##name,nparamsmin,nparamsmax,pmask}
 static const SQRegFunction stringlib_funcs[]={
-    _DECL_FUNC(format,-2,_SC(".s")),
-    _DECL_FUNC(printf,-2,_SC(".s")),
-    _DECL_FUNC(strip,2,_SC(".s")),
-    _DECL_FUNC(lstrip,2,_SC(".s")),
-    _DECL_FUNC(rstrip,2,_SC(".s")),
-    _DECL_FUNC(split,-3,_SC(".ssb")),
-    _DECL_FUNC(escape,2,_SC(".s")),
-    _DECL_FUNC(startswith,3,_SC(".ss")),
-    _DECL_FUNC(endswith,3,_SC(".ss")),
-    {NULL,(SQFUNCTION)0,0,NULL}
+    _DECL_FUNC(format,2,0,_SC(".s")),
+    _DECL_FUNC(printf,2,0,_SC(".s")),
+    _DECL_FUNC(strip,2,2,_SC(".s")),
+    _DECL_FUNC(lstrip,2,2,_SC(".s")),
+    _DECL_FUNC(rstrip,2,2,_SC(".s")),
+    _DECL_FUNC(split,3,0,_SC(".ssb")),
+    _DECL_FUNC(escape,2,2,_SC(".s")),
+    _DECL_FUNC(startswith,3,3,_SC(".ss")),
+    _DECL_FUNC(endswith,3,3,_SC(".ss")),
+    {NULL,(SQFUNCTION)0,0,0,NULL}
 };
 #undef _DECL_FUNC
 
@@ -531,7 +531,7 @@ SQInteger sqstd_register_stringlib(HSQUIRRELVM v)
         const SQRegFunction &f = rexobj_funcs[i];
         sq_pushstring(v,f.name,-1);
         sq_newclosure(v,f.f,0);
-        sq_setparamscheck(v,f.nparamscheck,f.typemask);
+        sq_setparamscheck(v,f.nparamscheckmin,f.nparamscheckmax,f.typemask);
         sq_setnativeclosurename(v,-1,f.name);
         sq_newslot(v,-3,SQFalse);
         i++;
@@ -543,7 +543,7 @@ SQInteger sqstd_register_stringlib(HSQUIRRELVM v)
     {
         sq_pushstring(v,stringlib_funcs[i].name,-1);
         sq_newclosure(v,stringlib_funcs[i].f,0);
-        sq_setparamscheck(v,stringlib_funcs[i].nparamscheck,stringlib_funcs[i].typemask);
+        sq_setparamscheck(v,stringlib_funcs[i].nparamscheckmin,stringlib_funcs[i].nparamscheckmax,stringlib_funcs[i].typemask);
         sq_setnativeclosurename(v,-1,stringlib_funcs[i].name);
         sq_newslot(v,-3,SQFalse);
         i++;

--- a/sqstdlib/sqstdsystem.cpp
+++ b/sqstdlib/sqstdsystem.cpp
@@ -132,16 +132,16 @@ static SQInteger _system_date(HSQUIRRELVM v)
 
 
 
-#define _DECL_FUNC(name,nparams,pmask) {_SC(#name),_system_##name,nparams,pmask}
+#define _DECL_FUNC(name,nparamsmin,nparamsmax,pmask) {_SC(#name),_system_##name,nparamsmin,nparamsmax,pmask}
 static const SQRegFunction systemlib_funcs[]={
-    _DECL_FUNC(getenv,2,_SC(".s")),
-    _DECL_FUNC(system,2,_SC(".s")),
-    _DECL_FUNC(clock,0,NULL),
-    _DECL_FUNC(time,1,NULL),
-    _DECL_FUNC(date,-1,_SC(".nn")),
-    _DECL_FUNC(remove,2,_SC(".s")),
-    _DECL_FUNC(rename,3,_SC(".ss")),
-    {NULL,(SQFUNCTION)0,0,NULL}
+    _DECL_FUNC(getenv,2,2,_SC(".s")),
+    _DECL_FUNC(system,2,2,_SC(".s")),
+    _DECL_FUNC(clock,0,0,NULL),
+    _DECL_FUNC(time,1,1,NULL),
+    _DECL_FUNC(date,1,0,_SC(".nn")),
+    _DECL_FUNC(remove,2,2,_SC(".s")),
+    _DECL_FUNC(rename,3,3,_SC(".ss")),
+    {NULL,(SQFUNCTION)0,0,0,NULL}
 };
 #undef _DECL_FUNC
 
@@ -152,7 +152,7 @@ SQInteger sqstd_register_systemlib(HSQUIRRELVM v)
     {
         sq_pushstring(v,systemlib_funcs[i].name,-1);
         sq_newclosure(v,systemlib_funcs[i].f,0);
-        sq_setparamscheck(v,systemlib_funcs[i].nparamscheck,systemlib_funcs[i].typemask);
+        sq_setparamscheck(v,systemlib_funcs[i].nparamscheckmin,systemlib_funcs[i].nparamscheckmax,systemlib_funcs[i].typemask);
         sq_setnativeclosurename(v,-1,systemlib_funcs[i].name);
         sq_newslot(v,-3,SQFalse);
         i++;

--- a/squirrel/sqbaselib.cpp
+++ b/squirrel/sqbaselib.cpp
@@ -282,29 +282,29 @@ static SQInteger base_callee(HSQUIRRELVM v)
 
 static const SQRegFunction base_funcs[]={
     //generic
-    {_SC("seterrorhandler"),base_seterrorhandler,2, NULL},
-    {_SC("setdebughook"),base_setdebughook,2, NULL},
-    {_SC("enabledebuginfo"),base_enabledebuginfo,2, NULL},
-    {_SC("getstackinfos"),base_getstackinfos,2, _SC(".n")},
-    {_SC("getroottable"),base_getroottable,1, NULL},
-    {_SC("setroottable"),base_setroottable,2, NULL},
-    {_SC("getconsttable"),base_getconsttable,1, NULL},
-    {_SC("setconsttable"),base_setconsttable,2, NULL},
-    {_SC("assert"),base_assert,-2, NULL},
-    {_SC("print"),base_print,2, NULL},
-    {_SC("error"),base_error,2, NULL},
-    {_SC("compilestring"),base_compilestring,-2, _SC(".ss")},
-    {_SC("newthread"),base_newthread,2, _SC(".c")},
-    {_SC("suspend"),base_suspend,-1, NULL},
-    {_SC("array"),base_array,-2, _SC(".n")},
-    {_SC("type"),base_type,2, NULL},
-    {_SC("callee"),base_callee,0,NULL},
-    {_SC("dummy"),base_dummy,0,NULL},
+    {_SC("seterrorhandler"),base_seterrorhandler,2,2, NULL},
+    {_SC("setdebughook"),base_setdebughook,2,2, NULL},
+    {_SC("enabledebuginfo"),base_enabledebuginfo,2,2, NULL},
+    {_SC("getstackinfos"),base_getstackinfos,2,2, _SC(".n")},
+    {_SC("getroottable"),base_getroottable,1,1, NULL},
+    {_SC("setroottable"),base_setroottable,2,2, NULL},
+    {_SC("getconsttable"),base_getconsttable,1,1, NULL},
+    {_SC("setconsttable"),base_setconsttable,2,2, NULL},
+    {_SC("assert"),base_assert,2,0, NULL},
+    {_SC("print"),base_print,2,2, NULL},
+    {_SC("error"),base_error,2,2, NULL},
+    {_SC("compilestring"),base_compilestring,2,0, _SC(".ss")},
+    {_SC("newthread"),base_newthread,2,2, _SC(".c")},
+    {_SC("suspend"),base_suspend,1,0, NULL},
+    {_SC("array"),base_array,2,0, _SC(".n")},
+    {_SC("type"),base_type,2,2, NULL},
+    {_SC("callee"),base_callee,0,0,NULL},
+    {_SC("dummy"),base_dummy,0,0,NULL},
 #ifndef NO_GARBAGE_COLLECTOR
-    {_SC("collectgarbage"),base_collectgarbage,0, NULL},
-    {_SC("resurrectunreachable"),base_resurectureachable,0, NULL},
+    {_SC("collectgarbage"),base_collectgarbage,0,0, NULL},
+    {_SC("resurrectunreachable"),base_resurectureachable,0,0, NULL},
 #endif
-    {NULL,(SQFUNCTION)0,0,NULL}
+    {NULL,(SQFUNCTION)0,0,0,NULL}
 };
 
 void sq_base_register(HSQUIRRELVM v)
@@ -315,7 +315,7 @@ void sq_base_register(HSQUIRRELVM v)
         sq_pushstring(v,base_funcs[i].name,-1);
         sq_newclosure(v,base_funcs[i].f,0);
         sq_setnativeclosurename(v,-1,base_funcs[i].name);
-        sq_setparamscheck(v,base_funcs[i].nparamscheck,base_funcs[i].typemask);
+        sq_setparamscheck(v,base_funcs[i].nparamscheckmin,base_funcs[i].nparamscheckmax,base_funcs[i].typemask);
         sq_newslot(v,-3, SQFalse);
         i++;
     }
@@ -551,21 +551,21 @@ TABLE_TO_ARRAY_FUNC(table_values, val)
 
 
 const SQRegFunction SQSharedState::_table_default_delegate_funcz[]={
-    {_SC("len"),default_delegate_len,1, _SC("t")},
-    {_SC("rawget"),container_rawget,2, _SC("t")},
-    {_SC("rawset"),container_rawset,3, _SC("t")},
-    {_SC("rawdelete"),table_rawdelete,2, _SC("t")},
-    {_SC("rawin"),container_rawexists,2, _SC("t")},
-    {_SC("weakref"),obj_delegate_weakref,1, NULL },
-    {_SC("tostring"),default_delegate_tostring,1, _SC(".")},
-    {_SC("clear"),obj_clear,1, _SC(".")},
-    {_SC("setdelegate"),table_setdelegate,2, _SC(".t|o")},
-    {_SC("getdelegate"),table_getdelegate,1, _SC(".")},
-    {_SC("filter"),table_filter,2, _SC("tc")},
-	{_SC("map"),table_map,2, _SC("tc") },
-	{_SC("keys"),table_keys,1, _SC("t") },
-	{_SC("values"),table_values,1, _SC("t") },
-    {NULL,(SQFUNCTION)0,0,NULL}
+    {_SC("len"),default_delegate_len,1,1, _SC("t")},
+    {_SC("rawget"),container_rawget,2,2, _SC("t")},
+    {_SC("rawset"),container_rawset,3,3, _SC("t")},
+    {_SC("rawdelete"),table_rawdelete,2,2, _SC("t")},
+    {_SC("rawin"),container_rawexists,2,2, _SC("t")},
+    {_SC("weakref"),obj_delegate_weakref,1,1, NULL },
+    {_SC("tostring"),default_delegate_tostring,1,1, _SC(".")},
+    {_SC("clear"),obj_clear,1,1, _SC(".")},
+    {_SC("setdelegate"),table_setdelegate,2,2, _SC(".t|o")},
+    {_SC("getdelegate"),table_getdelegate,1,1, _SC(".")},
+    {_SC("filter"),table_filter,2,2, _SC("tc")},
+	{_SC("map"),table_map,2,2, _SC("tc") },
+	{_SC("keys"),table_keys,1,1, _SC("t") },
+	{_SC("values"),table_values,1,1, _SC("t") },
+    {NULL,(SQFUNCTION)0,0,0,NULL}
 };
 
 //ARRAY DEFAULT DELEGATE///////////////////////////////////////
@@ -657,9 +657,9 @@ static SQInteger __map_array(SQArray *dest,SQArray *src,HSQUIRRELVM v) {
         nArgs = _closure(closure)->_function->_nparameters;
     }
     else if (sq_type(closure) == OT_NATIVECLOSURE) {
-        SQInteger nParamsCheck = _nativeclosure(closure)->_nparamscheck;
-        if (nParamsCheck > 0)
-            nArgs = nParamsCheck;
+        SQInteger nParamsCheckMax = _nativeclosure(closure)->_nparamscheckmax;
+        if (nParamsCheckMax < 4)
+            nArgs = nParamsCheckMax;
         else // push all params when there is no check or only minimal count set
             nArgs = 4;
     }
@@ -907,27 +907,27 @@ static SQInteger array_slice(HSQUIRRELVM v)
 }
 
 const SQRegFunction SQSharedState::_array_default_delegate_funcz[]={
-    {_SC("len"),default_delegate_len,1, _SC("a")},
-    {_SC("append"),array_append,2, _SC("a")},
-    {_SC("extend"),array_extend,2, _SC("aa")},
-    {_SC("push"),array_append,2, _SC("a")},
-    {_SC("pop"),array_pop,1, _SC("a")},
-    {_SC("top"),array_top,1, _SC("a")},
-    {_SC("insert"),array_insert,3, _SC("an")},
-    {_SC("remove"),array_remove,2, _SC("an")},
-    {_SC("resize"),array_resize,-2, _SC("an")},
-    {_SC("reverse"),array_reverse,1, _SC("a")},
-    {_SC("sort"),array_sort,-1, _SC("ac")},
-    {_SC("slice"),array_slice,-1, _SC("ann")},
-    {_SC("weakref"),obj_delegate_weakref,1, NULL },
-    {_SC("tostring"),default_delegate_tostring,1, _SC(".")},
-    {_SC("clear"),obj_clear,1, _SC(".")},
-    {_SC("map"),array_map,2, _SC("ac")},
-    {_SC("apply"),array_apply,2, _SC("ac")},
-    {_SC("reduce"),array_reduce,-2, _SC("ac.")},
-    {_SC("filter"),array_filter,2, _SC("ac")},
-    {_SC("find"),array_find,2, _SC("a.")},
-    {NULL,(SQFUNCTION)0,0,NULL}
+    {_SC("len"),default_delegate_len,1,1, _SC("a")},
+    {_SC("append"),array_append,2,2, _SC("a")},
+    {_SC("extend"),array_extend,2,2, _SC("aa")},
+    {_SC("push"),array_append,2,2, _SC("a")},
+    {_SC("pop"),array_pop,1,1, _SC("a")},
+    {_SC("top"),array_top,1,1, _SC("a")},
+    {_SC("insert"),array_insert,3,3, _SC("an")},
+    {_SC("remove"),array_remove,2,2, _SC("an")},
+    {_SC("resize"),array_resize,2,0, _SC("an")},
+    {_SC("reverse"),array_reverse,1,1, _SC("a")},
+    {_SC("sort"),array_sort,1,0, _SC("ac")},
+    {_SC("slice"),array_slice,1,0, _SC("ann")},
+    {_SC("weakref"),obj_delegate_weakref,1,1, NULL },
+    {_SC("tostring"),default_delegate_tostring,1,1, _SC(".")},
+    {_SC("clear"),obj_clear,1,1, _SC(".")},
+    {_SC("map"),array_map,2,2, _SC("ac")},
+    {_SC("apply"),array_apply,2,2, _SC("ac")},
+    {_SC("reduce"),array_reduce,2,0, _SC("ac.")},
+    {_SC("filter"),array_filter,2,2, _SC("ac")},
+    {_SC("find"),array_find,2,2, _SC("a.")},
+    {NULL,(SQFUNCTION)0,0,0,NULL}
 };
 
 //STRING DEFAULT DELEGATE//////////////////////////
@@ -987,26 +987,26 @@ STRING_TOFUNCZ(tolower)
 STRING_TOFUNCZ(toupper)
 
 const SQRegFunction SQSharedState::_string_default_delegate_funcz[]={
-    {_SC("len"),default_delegate_len,1, _SC("s")},
-    {_SC("tointeger"),default_delegate_tointeger,-1, _SC("sn")},
-    {_SC("tofloat"),default_delegate_tofloat,1, _SC("s")},
-    {_SC("tostring"),default_delegate_tostring,1, _SC(".")},
-    {_SC("slice"),string_slice,-1, _SC("s n  n")},
-    {_SC("find"),string_find,-2, _SC("s s n")},
-    {_SC("tolower"),string_tolower,-1, _SC("s n n")},
-    {_SC("toupper"),string_toupper,-1, _SC("s n n")},
-    {_SC("weakref"),obj_delegate_weakref,1, NULL },
-    {NULL,(SQFUNCTION)0,0,NULL}
+    {_SC("len"),default_delegate_len,1,1, _SC("s")},
+    {_SC("tointeger"),default_delegate_tointeger,1,0, _SC("sn")},
+    {_SC("tofloat"),default_delegate_tofloat,1,1, _SC("s")},
+    {_SC("tostring"),default_delegate_tostring,1,1, _SC(".")},
+    {_SC("slice"),string_slice,1,0, _SC("s n  n")},
+    {_SC("find"),string_find,2,0, _SC("s s n")},
+    {_SC("tolower"),string_tolower,1,0, _SC("s n n")},
+    {_SC("toupper"),string_toupper,1,0, _SC("s n n")},
+    {_SC("weakref"),obj_delegate_weakref,1,1, NULL },
+    {NULL,(SQFUNCTION)0,0,0,NULL}
 };
 
 //INTEGER DEFAULT DELEGATE//////////////////////////
 const SQRegFunction SQSharedState::_number_default_delegate_funcz[]={
-    {_SC("tointeger"),default_delegate_tointeger,1, _SC("n|b")},
-    {_SC("tofloat"),default_delegate_tofloat,1, _SC("n|b")},
-    {_SC("tostring"),default_delegate_tostring,1, _SC(".")},
-    {_SC("tochar"),number_delegate_tochar,1, _SC("n|b")},
-    {_SC("weakref"),obj_delegate_weakref,1, NULL },
-    {NULL,(SQFUNCTION)0,0,NULL}
+    {_SC("tointeger"),default_delegate_tointeger,1,1, _SC("n|b")},
+    {_SC("tofloat"),default_delegate_tofloat,1,1, _SC("n|b")},
+    {_SC("tostring"),default_delegate_tostring,1,1, _SC(".")},
+    {_SC("tochar"),number_delegate_tochar,1,1, _SC("n|b")},
+    {_SC("weakref"),obj_delegate_weakref,1,1, NULL },
+    {NULL,(SQFUNCTION)0,0,0,NULL}
 };
 
 //CLOSURE DEFAULT DELEGATE//////////////////////////
@@ -1093,7 +1093,8 @@ static SQInteger closure_getinfos(HSQUIRRELVM v) {
         SQNativeClosure *nc = _nativeclosure(o);
         res->NewSlot(SQString::Create(_ss(v),_SC("native"),-1),true);
         res->NewSlot(SQString::Create(_ss(v),_SC("name"),-1),nc->_name);
-        res->NewSlot(SQString::Create(_ss(v),_SC("paramscheck"),-1),nc->_nparamscheck);
+        res->NewSlot(SQString::Create(_ss(v),_SC("paramscheckmin"),-1),nc->_nparamscheckmin);
+        res->NewSlot(SQString::Create(_ss(v),_SC("paramscheckmax"),-1),nc->_nparamscheckmax);
         SQObjectPtr typecheck;
         if(nc->_typecheck.size() > 0) {
             typecheck =
@@ -1111,17 +1112,17 @@ static SQInteger closure_getinfos(HSQUIRRELVM v) {
 
 
 const SQRegFunction SQSharedState::_closure_default_delegate_funcz[]={
-    {_SC("call"),closure_call,-1, _SC("c")},
-    {_SC("pcall"),closure_pcall,-1, _SC("c")},
-    {_SC("acall"),closure_acall,2, _SC("ca")},
-    {_SC("pacall"),closure_pacall,2, _SC("ca")},
-    {_SC("weakref"),obj_delegate_weakref,1, NULL },
-    {_SC("tostring"),default_delegate_tostring,1, _SC(".")},
-    {_SC("bindenv"),closure_bindenv,2, _SC("c x|y|t")},
-    {_SC("getinfos"),closure_getinfos,1, _SC("c")},
-    {_SC("getroot"),closure_getroot,1, _SC("c")},
-    {_SC("setroot"),closure_setroot,2, _SC("ct")},
-    {NULL,(SQFUNCTION)0,0,NULL}
+    {_SC("call"),closure_call,1,0, _SC("c")},
+    {_SC("pcall"),closure_pcall,1,0, _SC("c")},
+    {_SC("acall"),closure_acall,2,2, _SC("ca")},
+    {_SC("pacall"),closure_pacall,2,2, _SC("ca")},
+    {_SC("weakref"),obj_delegate_weakref,1,1, NULL },
+    {_SC("tostring"),default_delegate_tostring,1,1, _SC(".")},
+    {_SC("bindenv"),closure_bindenv,2,2, _SC("c x|y|t")},
+    {_SC("getinfos"),closure_getinfos,1,1, _SC("c")},
+    {_SC("getroot"),closure_getroot,1,1, _SC("c")},
+    {_SC("setroot"),closure_setroot,2,2, _SC("ct")},
+    {NULL,(SQFUNCTION)0,0,0,NULL}
 };
 
 //GENERATOR DEFAULT DELEGATE
@@ -1137,10 +1138,10 @@ static SQInteger generator_getstatus(HSQUIRRELVM v)
 }
 
 const SQRegFunction SQSharedState::_generator_default_delegate_funcz[]={
-    {_SC("getstatus"),generator_getstatus,1, _SC("g")},
-    {_SC("weakref"),obj_delegate_weakref,1, NULL },
-    {_SC("tostring"),default_delegate_tostring,1, _SC(".")},
-    {NULL,(SQFUNCTION)0,0,NULL}
+    {_SC("getstatus"),generator_getstatus,1,1, _SC("g")},
+    {_SC("weakref"),obj_delegate_weakref,1,1, NULL },
+    {_SC("tostring"),default_delegate_tostring,1,1, _SC(".")},
+    {NULL,(SQFUNCTION)0,0,0,NULL}
 };
 
 //THREAD DEFAULT DELEGATE
@@ -1294,14 +1295,14 @@ static SQInteger thread_getstackinfos(HSQUIRRELVM v)
 }
 
 const SQRegFunction SQSharedState::_thread_default_delegate_funcz[] = {
-    {_SC("call"), thread_call, -1, _SC("v")},
-    {_SC("wakeup"), thread_wakeup, -1, _SC("v")},
-    {_SC("wakeupthrow"), thread_wakeupthrow, -2, _SC("v.b")},
-    {_SC("getstatus"), thread_getstatus, 1, _SC("v")},
-    {_SC("weakref"),obj_delegate_weakref,1, NULL },
-    {_SC("getstackinfos"),thread_getstackinfos,2, _SC("vn")},
-    {_SC("tostring"),default_delegate_tostring,1, _SC(".")},
-    {NULL,(SQFUNCTION)0,0,NULL}
+    {_SC("call"), thread_call, 1, 0, _SC("v")},
+    {_SC("wakeup"), thread_wakeup, 1, 0, _SC("v")},
+    {_SC("wakeupthrow"), thread_wakeupthrow, 2, 0, _SC("v.b")},
+    {_SC("getstatus"), thread_getstatus, 1, 1, _SC("v")},
+    {_SC("weakref"),obj_delegate_weakref,1, 1, NULL },
+    {_SC("getstackinfos"),thread_getstackinfos,2,2, _SC("vn")},
+    {_SC("tostring"),default_delegate_tostring,1,1, _SC(".")},
+    {NULL,(SQFUNCTION)0,0,0,NULL}
 };
 
 static SQInteger class_getattributes(HSQUIRRELVM v)
@@ -1357,18 +1358,18 @@ static SQInteger class_rawnewmember(HSQUIRRELVM v)
 }
 
 const SQRegFunction SQSharedState::_class_default_delegate_funcz[] = {
-    {_SC("getattributes"), class_getattributes, 2, _SC("y.")},
-    {_SC("setattributes"), class_setattributes, 3, _SC("y..")},
-    {_SC("rawget"),container_rawget,2, _SC("y")},
-    {_SC("rawset"),container_rawset,3, _SC("y")},
-    {_SC("rawin"),container_rawexists,2, _SC("y")},
-    {_SC("weakref"),obj_delegate_weakref,1, NULL },
-    {_SC("tostring"),default_delegate_tostring,1, _SC(".")},
-    {_SC("instance"),class_instance,1, _SC("y")},
-    {_SC("getbase"),class_getbase,1, _SC("y")},
-    {_SC("newmember"),class_newmember,-3, _SC("y")},
-    {_SC("rawnewmember"),class_rawnewmember,-3, _SC("y")},
-    {NULL,(SQFUNCTION)0,0,NULL}
+    {_SC("getattributes"), class_getattributes, 2, 2, _SC("y.")},
+    {_SC("setattributes"), class_setattributes, 3, 3, _SC("y..")},
+    {_SC("rawget"),container_rawget,2,2, _SC("y")},
+    {_SC("rawset"),container_rawset,3,3, _SC("y")},
+    {_SC("rawin"),container_rawexists,2,2, _SC("y")},
+    {_SC("weakref"),obj_delegate_weakref,1,1, NULL },
+    {_SC("tostring"),default_delegate_tostring,1,1, _SC(".")},
+    {_SC("instance"),class_instance,1,1, _SC("y")},
+    {_SC("getbase"),class_getbase,1,1, _SC("y")},
+    {_SC("newmember"),class_newmember,3,0, _SC("y")},
+    {_SC("rawnewmember"),class_rawnewmember,3,0, _SC("y")},
+    {NULL,(SQFUNCTION)0,0,0,NULL}
 };
 
 
@@ -1380,13 +1381,13 @@ static SQInteger instance_getclass(HSQUIRRELVM v)
 }
 
 const SQRegFunction SQSharedState::_instance_default_delegate_funcz[] = {
-    {_SC("getclass"), instance_getclass, 1, _SC("x")},
-    {_SC("rawget"),container_rawget,2, _SC("x")},
-    {_SC("rawset"),container_rawset,3, _SC("x")},
-    {_SC("rawin"),container_rawexists,2, _SC("x")},
-    {_SC("weakref"),obj_delegate_weakref,1, NULL },
-    {_SC("tostring"),default_delegate_tostring,1, _SC(".")},
-    {NULL,(SQFUNCTION)0,0,NULL}
+    {_SC("getclass"), instance_getclass, 1, 1, _SC("x")},
+    {_SC("rawget"),container_rawget,2,2, _SC("x")},
+    {_SC("rawset"),container_rawset,3,3, _SC("x")},
+    {_SC("rawin"),container_rawexists,2,2, _SC("x")},
+    {_SC("weakref"),obj_delegate_weakref,1,1, NULL },
+    {_SC("tostring"),default_delegate_tostring,1,1, _SC(".")},
+    {NULL,(SQFUNCTION)0,0,0,NULL}
 };
 
 static SQInteger weakref_ref(HSQUIRRELVM v)
@@ -1397,8 +1398,8 @@ static SQInteger weakref_ref(HSQUIRRELVM v)
 }
 
 const SQRegFunction SQSharedState::_weakref_default_delegate_funcz[] = {
-    {_SC("ref"),weakref_ref,1, _SC("r")},
-    {_SC("weakref"),obj_delegate_weakref,1, NULL },
-    {_SC("tostring"),default_delegate_tostring,1, _SC(".")},
-    {NULL,(SQFUNCTION)0,0,NULL}
+    {_SC("ref"),weakref_ref,1,1, _SC("r")},
+    {_SC("weakref"),obj_delegate_weakref,1,1, NULL },
+    {_SC("tostring"),default_delegate_tostring,1,1, _SC(".")},
+    {NULL,(SQFUNCTION)0,0,0,NULL}
 };

--- a/squirrel/sqclosure.h
+++ b/squirrel/sqclosure.h
@@ -167,7 +167,8 @@ public:
         ret->_name = _name;
         _COPY_VECTOR(ret->_outervalues,_outervalues,_noutervalues);
         ret->_typecheck.copy(_typecheck);
-        ret->_nparamscheck = _nparamscheck;
+        ret->_nparamscheckmin = _nparamscheckmin;
+        ret->_nparamscheckmax = _nparamscheckmax;
         return ret;
     }
     ~SQNativeClosure()
@@ -187,7 +188,8 @@ public:
     void Finalize() { _NULL_SQOBJECT_VECTOR(_outervalues,_noutervalues); }
     SQObjectType GetType() {return OT_NATIVECLOSURE;}
 #endif
-    SQInteger _nparamscheck;
+    SQInteger _nparamscheckmin;
+    SQInteger _nparamscheckmax;
     SQIntVec _typecheck;
     SQObjectPtr *_outervalues;
     SQUnsignedInteger _noutervalues;

--- a/squirrel/sqstate.cpp
+++ b/squirrel/sqstate.cpp
@@ -79,7 +79,8 @@ SQTable *CreateDefaultDelegate(SQSharedState *ss,const SQRegFunction *funcz)
     SQTable *t=SQTable::Create(ss,0);
     while(funcz[i].name!=0){
         SQNativeClosure *nc = SQNativeClosure::Create(ss,funcz[i].f,0);
-        nc->_nparamscheck = funcz[i].nparamscheck;
+        nc->_nparamscheckmin = funcz[i].nparamscheckmin;
+        nc->_nparamscheckmax = funcz[i].nparamscheckmax;
         nc->_name = SQString::Create(ss,funcz[i].name);
         if(funcz[i].typemask && !CompileTypemask(nc->_typecheck,funcz[i].typemask))
             return NULL;

--- a/squirrel/sqvm.cpp
+++ b/squirrel/sqvm.cpp
@@ -1174,7 +1174,6 @@ void SQVM::CallDebugHook(SQInteger type,SQInteger forcedline)
 
 bool SQVM::CallNative(SQNativeClosure *nclosure, SQInteger nargs, SQInteger newbase, SQObjectPtr &retval, SQInt32 target,bool &suspend, bool &tailcall)
 {
-    SQInteger nparamscheck = nclosure->_nparamscheck;
     SQInteger newtop = newbase + nargs + nclosure->_noutervalues;
 
     if (_nnativecalls + 1 > MAX_NATIVE_CALLS) {
@@ -1182,8 +1181,8 @@ bool SQVM::CallNative(SQNativeClosure *nclosure, SQInteger nargs, SQInteger newb
         return false;
     }
 
-    if(nparamscheck && (((nparamscheck > 0) && (nparamscheck != nargs)) ||
-        ((nparamscheck < 0) && (nargs < (-nparamscheck)))))
+    if((nclosure->_nparamscheckmin > 0 && nargs < nclosure->_nparamscheckmin) ||
+         (nclosure->_nparamscheckmax > 0 && nargs > nclosure->_nparamscheckmax))
     {
         Raise_Error(_SC("wrong number of parameters"));
         return false;


### PR DESCRIPTION
The `sq_setparamscheck` function, instead of accepting just the `SQInteger nparamscheck` parameter, now accepts both `SQInteger nparamscheckmin` and `SQInteger nparamscheckmax`.

Those define the minimum/maximum for the parameters number check policy. Setting any of them to 0 or negative disables the respective check.

I believe this change makes the parameter check way less restrictive and suitable for more use-cases. For example, it enables support for default arguments.

---

**NOTE:** This change makes changes to the API functions `sq_setparamscheck` and `sq_getclosureinfo`. I am not sure how Squirrel handles such changes (deprecation mechanic?). Because of this, I understand that this change might not be suitable for upstream.