### PR TITLE
Fix undefined behavior

### DIFF
--- a/squirrel/sqstate.cpp
+++ b/squirrel/sqstate.cpp
@@ -376,13 +376,13 @@ SQChar* SQSharedState::GetScratchPad(SQInteger size)
     SQInteger newsize;
     if (size > 0) {
         if (_scratchpadsize < size) {
-            newsize = size + (size >> 1);
+            newsize = (SQInteger)((SQUnsignedInteger)size + (size >> 1));
             newsize = sq_max(newsize, size); //check for overflow
             _scratchpad = (SQChar*)SQ_REALLOC(_scratchpad, _scratchpadsize, newsize);
             _scratchpadsize = newsize;
 
         }
-        else if (_scratchpadsize >= (size << 5)) {
+        else if ((_scratchpadsize >> 5) >= size) {
             newsize = _scratchpadsize >> 1;
             newsize = sq_max(newsize, size); //check for overflow
             _scratchpad = (SQChar*)SQ_REALLOC(_scratchpad, _scratchpadsize, newsize);


### PR DESCRIPTION
Do not let the compiler optimize out security check. See #294 