### PR TITLE
Fix warning build with memmove

### DIFF
--- a/squirrel/squtils.h
+++ b/squirrel/squtils.h
@@ -95,7 +95,7 @@ public:
     {
         _vals[idx].~T();
         if(idx < (_size - 1)) {
-            memmove(&_vals[idx], &_vals[idx+1], sizeof(T) * (_size - idx - 1));
+            memmove((void*)&_vals[idx], &_vals[idx+1], sizeof(T) * (_size - idx - 1));
         }
         _size--;
     }


### PR DESCRIPTION
Fix warning build on gcc with `memmove()` function between `void*` and `struct SQObjectPtr` types :

```
$ make
mkdir -p lib
mkdir -p bin
cd squirrel; make
make[1]: Entering directory '/home/user/Documents/squirrel/squirrel'
cc -O2 -fno-exceptions -fno-rtti -Wall -fno-strict-aliasing -c sqapi.cpp sqbaselib.cpp sqfuncstate.cpp sqdebug.cpp sqlexer.cpp sqobject.cpp sqcompiler.cpp sqstate.cpp sqtable.cpp sqmem.cpp sqvm.cpp sqclass.cpp -I../include -I. -Iinclude 
In file included from sqobject.h:5,
                 from sqpcheader.h:17,
                 from sqapi.cpp:4:
squtils.h: In instantiation of 'void sqvector<T>::remove(SQUnsignedInteger) [with T = SQObjectPtr; SQUnsignedInteger = long long unsigned int]':
sqarray.h:83:23:   required from here
squtils.h:98:20: warning: 'void* memmove(void*, const void*, size_t)' writing to an object of type 'struct SQObjectPtr' with no trivial copy-assignment; use copy-assignment or copy-initialization instead [-Wclass-memaccess]
   98 |             memmove(&_vals[idx], &_vals[idx+1], sizeof(T) * (_size - idx - 1));
      |             ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
sqobject.h:205:8: note: 'struct SQObjectPtr' declared here
  205 | struct SQObjectPtr : public SQObject
      |        ^~~~~~~~~~~
In file included from sqobject.h:5,
                 from sqpcheader.h:17,
                 from sqbaselib.cpp:4:
squtils.h: In instantiation of 'void sqvector<T>::remove(SQUnsignedInteger) [with T = SQObjectPtr; SQUnsignedInteger = long long unsigned int]':
sqarray.h:83:23:   required from here
squtils.h:98:20: warning: 'void* memmove(void*, const void*, size_t)' writing to an object of type 'struct SQObjectPtr' with no trivial copy-assignment; use copy-assignment or copy-initialization instead [-Wclass-memaccess]
   98 |             memmove(&_vals[idx], &_vals[idx+1], sizeof(T) * (_size - idx - 1));
      |             ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
sqobject.h:205:8: note: 'struct SQObjectPtr' declared here
  205 | struct SQObjectPtr : public SQObject
      |        ^~~~~~~~~~~
In file included from sqobject.h:5,
                 from sqpcheader.h:17,
                 from sqobject.cpp:4:
squtils.h: In instantiation of 'void sqvector<T>::remove(SQUnsignedInteger) [with T = SQObjectPtr; SQUnsignedInteger = long long unsigned int]':
sqarray.h:83:23:   required from here
squtils.h:98:20: warning: 'void* memmove(void*, const void*, size_t)' writing to an object of type 'struct SQObjectPtr' with no trivial copy-assignment; use copy-assignment or copy-initialization instead [-Wclass-memaccess]
   98 |             memmove(&_vals[idx], &_vals[idx+1], sizeof(T) * (_size - idx - 1));
      |             ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
sqobject.h:205:8: note: 'struct SQObjectPtr' declared here
  205 | struct SQObjectPtr : public SQObject
      |        ^~~~~~~~~~~
In file included from sqobject.h:5,
                 from sqpcheader.h:17,
                 from sqstate.cpp:4:
squtils.h: In instantiation of 'void sqvector<T>::remove(SQUnsignedInteger) [with T = SQObjectPtr; SQUnsignedInteger = long long unsigned int]':
sqarray.h:83:23:   required from here
squtils.h:98:20: warning: 'void* memmove(void*, const void*, size_t)' writing to an object of type 'struct SQObjectPtr' with no trivial copy-assignment; use copy-assignment or copy-initialization instead [-Wclass-memaccess]
   98 |             memmove(&_vals[idx], &_vals[idx+1], sizeof(T) * (_size - idx - 1));
      |             ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
sqobject.h:205:8: note: 'struct SQObjectPtr' declared here
  205 | struct SQObjectPtr : public SQObject
      |        ^~~~~~~~~~~
In file included from sqobject.h:5,
                 from sqpcheader.h:17,
                 from sqvm.cpp:4:
squtils.h: In instantiation of 'void sqvector<T>::remove(SQUnsignedInteger) [with T = SQObjectPtr; SQUnsignedInteger = long long unsigned int]':
sqarray.h:83:23:   required from here
squtils.h:98:20: warning: 'void* memmove(void*, const void*, size_t)' writing to an object of type 'struct SQObjectPtr' with no trivial copy-assignment; use copy-assignment or copy-initialization instead [-Wclass-memaccess]
   98 |             memmove(&_vals[idx], &_vals[idx+1], sizeof(T) * (_size - idx - 1));
      |             ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
sqobject.h:205:8: note: 'struct SQObjectPtr' declared here
  205 | struct SQObjectPtr : public SQObject
      |        ^~~~~~~~~~~
ar rc ../lib/libsquirrel.a *.o
rm *.o
make[1]: Leaving directory '/home/user/Documents/squirrel/squirrel'
cd sqstdlib; make
make[1]: Entering directory '/home/user/Documents/squirrel/sqstdlib'
cc -O2 -fno-exceptions -fno-rtti -Wall -fno-strict-aliasing -c sqstdblob.cpp sqstdio.cpp sqstdstream.cpp sqstdmath.cpp sqstdsystem.cpp sqstdstring.cpp sqstdaux.cpp sqstdrex.cpp -I../include -I. -Iinclude 
sqstdblob.cpp: In function 'SQInteger _g_blob_castf2i(HSQUIRRELVM)':
sqstdblob.cpp:200:19: warning: array subscript 'const SQInteger {aka const long long int}[0]' is partly outside array bounds of 'SQFloat [1]' {aka 'float [1]'} [-Warray-bounds=]
  200 |     sq_pushinteger(v,*((const SQInteger *)&f));
      |     ~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~
sqstdblob.cpp:198:13: note: object 'f' of size 4
  198 |     SQFloat f;
      |             ^
ar rc ../lib/libsqstdlib.a *.o
```