### PR TITLE
Add import function for external libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,6 +90,8 @@ if(NOT SQ_DISABLE_INSTALLER AND NOT SQ_DISABLE_HEADER_INSTALLER)
     include/sqstdmath.h
     include/sqstdstring.h
     include/sqstdsystem.h
+    include/sqstdimport.h
+    include/sqstdmodule.h
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
     COMPONENT Development
     )

--- a/include/sqstdimport.h
+++ b/include/sqstdimport.h
@@ -1,0 +1,15 @@
+/* see copyright notice in squirrel.h */
+#ifndef _SQSTD_IMPORT_H_
+#define _SQSTD_IMPORT_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+SQUIRREL_API SQRESULT sqstd_register_importlib(HSQUIRRELVM v);
+
+#ifdef __cplusplus
+} /*extern "C"*/
+#endif
+
+#endif //_SQSTD_IMPORT_H_

--- a/include/sqstdmodule.h
+++ b/include/sqstdmodule.h
@@ -1,0 +1,158 @@
+/* see copyright notice in squirrel.h */
+#ifndef _SQSTD_MODULE_H_
+#define _SQSTD_MODULE_H_
+
+#include <squirrel.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct {
+    /*vm*/
+        HSQUIRRELVM     (*open)(SQInteger initialstacksize);
+        HSQUIRRELVM     (*newthread)(HSQUIRRELVM friendvm, SQInteger initialstacksize);
+        void            (*seterrorhandler)(HSQUIRRELVM v);
+        void            (*close)(HSQUIRRELVM v);
+        void            (*setforeignptr)(HSQUIRRELVM v,SQUserPointer p);
+        SQUserPointer   (*getforeignptr)(HSQUIRRELVM v);
+        void            (*setprintfunc)(HSQUIRRELVM v, SQPRINTFUNCTION printfunc, SQPRINTFUNCTION);
+        SQPRINTFUNCTION (*getprintfunc)(HSQUIRRELVM v);
+        SQRESULT        (*suspendvm)(HSQUIRRELVM v);
+        SQRESULT        (*wakeupvm)(HSQUIRRELVM v,SQBool resumedret,SQBool retval,SQBool raiseerror,SQBool throwerror);
+        SQInteger       (*getvmstate)(HSQUIRRELVM v);
+
+        /*compiler*/
+        SQRESULT        (*compile)(HSQUIRRELVM v,SQLEXREADFUNC read,SQUserPointer p,const SQChar *sourcename,SQBool raiseerror);
+        SQRESULT        (*compilebuffer)(HSQUIRRELVM v,const SQChar *s,SQInteger size,const SQChar *sourcename,SQBool raiseerror);
+        void            (*enabledebuginfo)(HSQUIRRELVM v, SQBool enable);
+        void            (*notifyallexceptions)(HSQUIRRELVM v, SQBool enable);
+        void            (*setcompilererrorhandler)(HSQUIRRELVM v,SQCOMPILERERROR f);
+
+        /*stack operations*/
+        void            (*push)(HSQUIRRELVM v,SQInteger idx);
+        void            (*pop)(HSQUIRRELVM v,SQInteger nelemstopop);
+        void            (*poptop)(HSQUIRRELVM v);
+        void            (*remove)(HSQUIRRELVM v,SQInteger idx);
+        SQInteger       (*gettop)(HSQUIRRELVM v);
+        void            (*settop)(HSQUIRRELVM v,SQInteger newtop);
+        SQRESULT            (*reservestack)(HSQUIRRELVM v,SQInteger nsize);
+        SQInteger       (*cmp)(HSQUIRRELVM v);
+        void            (*move)(HSQUIRRELVM dest,HSQUIRRELVM src,SQInteger idx);
+
+        /*object creation handling*/
+        SQUserPointer   (*newuserdata)(HSQUIRRELVM v,SQUnsignedInteger size);
+        void            (*newtable)(HSQUIRRELVM v);
+        void            (*newarray)(HSQUIRRELVM v,SQInteger size);
+        void            (*newclosure)(HSQUIRRELVM v,SQFUNCTION func,SQUnsignedInteger nfreevars);
+        SQRESULT        (*setparamscheck)(HSQUIRRELVM v,SQInteger nparamscheck,const SQChar *typemask);
+        SQRESULT        (*bindenv)(HSQUIRRELVM v,SQInteger idx);
+        void            (*pushstring)(HSQUIRRELVM v,const SQChar *s,SQInteger len);
+        void            (*pushfloat)(HSQUIRRELVM v,SQFloat f);
+        void            (*pushinteger)(HSQUIRRELVM v,SQInteger n);
+        void            (*pushbool)(HSQUIRRELVM v,SQBool b);
+        void            (*pushuserpointer)(HSQUIRRELVM v,SQUserPointer p);
+        void            (*pushnull)(HSQUIRRELVM v);
+        SQObjectType    (*gettype)(HSQUIRRELVM v,SQInteger idx);
+        SQInteger       (*getsize)(HSQUIRRELVM v,SQInteger idx);
+        SQRESULT        (*getbase)(HSQUIRRELVM v,SQInteger idx);
+        SQBool          (*instanceof)(HSQUIRRELVM v);
+        SQRESULT        (*tostring)(HSQUIRRELVM v,SQInteger idx);
+        void            (*tobool)(HSQUIRRELVM v, SQInteger idx, SQBool *b);
+        SQRESULT        (*getstring)(HSQUIRRELVM v,SQInteger idx,const SQChar **c);
+        SQRESULT        (*getinteger)(HSQUIRRELVM v,SQInteger idx,SQInteger *i);
+        SQRESULT        (*getfloat)(HSQUIRRELVM v,SQInteger idx,SQFloat *f);
+        SQRESULT        (*getbool)(HSQUIRRELVM v,SQInteger idx,SQBool *b);
+        SQRESULT        (*getstringandsize)(HSQUIRRELVM v,SQInteger idx,const SQChar **c,SQInteger *size);
+        SQRESULT        (*getthread)(HSQUIRRELVM v,SQInteger idx,HSQUIRRELVM *thread);
+        SQRESULT        (*getuserpointer)(HSQUIRRELVM v,SQInteger idx,SQUserPointer *p);
+        SQRESULT        (*getuserdata)(HSQUIRRELVM v,SQInteger idx,SQUserPointer *p,SQUserPointer *typetag);
+        SQRESULT        (*settypetag)(HSQUIRRELVM v,SQInteger idx,SQUserPointer typetag);
+        SQRESULT        (*gettypetag)(HSQUIRRELVM v,SQInteger idx,SQUserPointer *typetag);
+        void            (*setreleasehook)(HSQUIRRELVM v,SQInteger idx,SQRELEASEHOOK hook);
+        SQChar*         (*getscratchpad)(HSQUIRRELVM v,SQInteger minsize);
+        SQRESULT        (*getclosureinfo)(HSQUIRRELVM v,SQInteger idx,SQInteger *nparams,SQInteger *nfreevars);
+        SQRESULT        (*setnativeclosurename)(HSQUIRRELVM v,SQInteger idx,const SQChar *name);
+        SQRESULT        (*setinstanceup)(HSQUIRRELVM v, SQInteger idx, SQUserPointer p);
+        SQRESULT        (*getinstanceup)(HSQUIRRELVM v, SQInteger idx, SQUserPointer *p,SQUserPointer typetag,SQBool throwerror);
+        SQRESULT        (*setclassudsize)(HSQUIRRELVM v, SQInteger idx, SQInteger udsize);
+        SQRESULT        (*newclass)(HSQUIRRELVM v,SQBool hasbase);
+        SQRESULT        (*createinstance)(HSQUIRRELVM v,SQInteger idx);
+        SQRESULT        (*setattributes)(HSQUIRRELVM v,SQInteger idx);
+        SQRESULT        (*getattributes)(HSQUIRRELVM v,SQInteger idx);
+        SQRESULT        (*getclass)(HSQUIRRELVM v,SQInteger idx);
+        void            (*weakref)(HSQUIRRELVM v,SQInteger idx);
+        SQRESULT        (*getdefaultdelegate)(HSQUIRRELVM v,SQObjectType t);
+
+        /*object manipulation*/
+        void            (*pushroottable)(HSQUIRRELVM v);
+        void            (*pushregistrytable)(HSQUIRRELVM v);
+        void            (*pushconsttable)(HSQUIRRELVM v);
+        SQRESULT        (*setroottable)(HSQUIRRELVM v);
+        SQRESULT        (*setconsttable)(HSQUIRRELVM v);
+        SQRESULT        (*newslot)(HSQUIRRELVM v, SQInteger idx, SQBool bstatic);
+        SQRESULT        (*deleteslot)(HSQUIRRELVM v,SQInteger idx,SQBool pushval);
+        SQRESULT        (*set)(HSQUIRRELVM v,SQInteger idx);
+        SQRESULT        (*get)(HSQUIRRELVM v,SQInteger idx);
+        SQRESULT        (*rawget)(HSQUIRRELVM v,SQInteger idx);
+        SQRESULT        (*rawset)(HSQUIRRELVM v,SQInteger idx);
+        SQRESULT        (*rawdeleteslot)(HSQUIRRELVM v,SQInteger idx,SQBool pushval);
+        SQRESULT        (*arrayappend)(HSQUIRRELVM v,SQInteger idx);
+        SQRESULT        (*arraypop)(HSQUIRRELVM v,SQInteger idx,SQBool pushval);
+        SQRESULT        (*arrayresize)(HSQUIRRELVM v,SQInteger idx,SQInteger newsize);
+        SQRESULT        (*arrayreverse)(HSQUIRRELVM v,SQInteger idx);
+        SQRESULT        (*arrayremove)(HSQUIRRELVM v,SQInteger idx,SQInteger itemidx);
+        SQRESULT        (*arrayinsert)(HSQUIRRELVM v,SQInteger idx,SQInteger destpos);
+        SQRESULT        (*setdelegate)(HSQUIRRELVM v,SQInteger idx);
+        SQRESULT        (*getdelegate)(HSQUIRRELVM v,SQInteger idx);
+        SQRESULT        (*clone)(HSQUIRRELVM v,SQInteger idx);
+        SQRESULT        (*setfreevariable)(HSQUIRRELVM v,SQInteger idx,SQUnsignedInteger nval);
+        SQRESULT        (*next)(HSQUIRRELVM v,SQInteger idx);
+        SQRESULT        (*getweakrefval)(HSQUIRRELVM v,SQInteger idx);
+        SQRESULT        (*clear)(HSQUIRRELVM v,SQInteger idx);
+
+        /*calls*/
+        SQRESULT        (*call)(HSQUIRRELVM v,SQInteger params,SQBool retval,SQBool raiseerror);
+        SQRESULT        (*resume)(HSQUIRRELVM v,SQBool retval,SQBool raiseerror);
+        const SQChar*   (*getlocal)(HSQUIRRELVM v,SQUnsignedInteger level,SQUnsignedInteger idx);
+        const SQChar*   (*getfreevariable)(HSQUIRRELVM v,SQInteger idx,SQUnsignedInteger nval);
+        SQRESULT        (*throwerror)(HSQUIRRELVM v,const SQChar *err);
+        void            (*reseterror)(HSQUIRRELVM v);
+        void            (*getlasterror)(HSQUIRRELVM v);
+
+        /*raw object handling*/
+        SQRESULT        (*getstackobj)(HSQUIRRELVM v,SQInteger idx,HSQOBJECT *po);
+        void            (*pushobject)(HSQUIRRELVM v,HSQOBJECT obj);
+        void            (*addref)(HSQUIRRELVM v,HSQOBJECT *po);
+        SQBool          (*release)(HSQUIRRELVM v,HSQOBJECT *po);
+        void            (*resetobject)(HSQOBJECT *po);
+        const SQChar*   (*objtostring)(const HSQOBJECT *o);
+        SQBool          (*objtobool)(const HSQOBJECT *o);
+        SQInteger       (*objtointeger)(const HSQOBJECT *o);
+        SQFloat         (*objtofloat)(const HSQOBJECT *o);
+        SQRESULT        (*getobjtypetag)(const HSQOBJECT *o,SQUserPointer * typetag);
+
+        /*GC*/
+        SQInteger       (*collectgarbage)(HSQUIRRELVM v);
+
+        /*serialization*/
+        SQRESULT        (*writeclosure)(HSQUIRRELVM vm,SQWRITEFUNC writef,SQUserPointer up);
+        SQRESULT        (*readclosure)(HSQUIRRELVM vm,SQREADFUNC readf,SQUserPointer up);
+
+        /*mem allocation*/
+        void*           (*malloc)(SQUnsignedInteger size);
+        void*           (*realloc)(void* p,SQUnsignedInteger oldsize,SQUnsignedInteger newsize);
+        void            (*free)(void *p,SQUnsignedInteger size);
+
+        /*debug*/
+        SQRESULT        (*stackinfos)(HSQUIRRELVM v,SQInteger level,SQStackInfos *si);
+        void            (*setdebughook)(HSQUIRRELVM v);
+} sq_api;
+
+typedef sq_api* HSQAPI;
+
+#ifdef __cplusplus
+} /*extern "C"*/
+#endif
+
+#endif //_SQSTD_MODULE_H_

--- a/sq/Makefile
+++ b/sq/Makefile
@@ -12,10 +12,10 @@ SRCS= sq.c
 
 
 sq32:
-	g++ -O2 -fno-exceptions -fno-rtti -o $(OUT) $(SRCS) $(INCZ) $(LIBZ) $(LIB)
+	g++ -ldl -O2 -fno-exceptions -fno-rtti -o $(OUT) $(SRCS) $(INCZ) $(LIBZ) $(LIB)
 
 sqprof:
-	g++ -O2 -pg -fno-exceptions -fno-rtti -pie -gstabs -g3 -o $(OUT) $(SRCS) $(INCZ) $(LIBZ) $(LIB)
+	g++ -ldl -O2 -pg -fno-exceptions -fno-rtti -pie -gstabs -g3 -o $(OUT) $(SRCS) $(INCZ) $(LIBZ) $(LIB)
 
 sq64:
-	g++ -O2 -m64 -fno-exceptions -fno-rtti -D_SQ64 -o $(OUT) $(SRCS) $(INCZ) $(LIBZ) $(LIB)
+	g++ -ldl -O2 -m64 -fno-exceptions -fno-rtti -D_SQ64 -o $(OUT) $(SRCS) $(INCZ) $(LIBZ) $(LIB)

--- a/sq/sq.c
+++ b/sq/sq.c
@@ -16,6 +16,7 @@
 #include <sqstdmath.h>
 #include <sqstdstring.h>
 #include <sqstdaux.h>
+#include <sqstdimport.h>
 
 #ifdef SQUNICODE
 #define scfprintf fwprintf
@@ -321,6 +322,7 @@ int main(int argc, char* argv[])
     sqstd_register_systemlib(v);
     sqstd_register_mathlib(v);
     sqstd_register_stringlib(v);
+    sqstd_register_importlib(v);
 
     //aux library
     //sets error handlers

--- a/sqstdlib/CMakeLists.txt
+++ b/sqstdlib/CMakeLists.txt
@@ -5,7 +5,8 @@ set(SQSTDLIB_SRC sqstdaux.cpp
                  sqstdrex.cpp
                  sqstdstream.cpp
                  sqstdstring.cpp
-                 sqstdsystem.cpp)
+                 sqstdsystem.cpp
+                 sqstdimport.cpp)
 
 if(NOT DISABLE_DYNAMIC)
   add_library(sqstdlib SHARED ${SQSTDLIB_SRC})

--- a/sqstdlib/Makefile
+++ b/sqstdlib/Makefile
@@ -15,7 +15,8 @@ OBJS= \
 	sqstdsystem.o \
 	sqstdstring.o \
 	sqstdaux.o \
-	sqstdrex.o
+	sqstdrex.o \
+	sqstdimport.o
 
 SRCS= \
 	sqstdblob.cpp \
@@ -25,7 +26,8 @@ SRCS= \
 	sqstdsystem.cpp \
 	sqstdstring.cpp \
 	sqstdaux.cpp \
-	sqstdrex.cpp
+	sqstdrex.cpp \
+	sqstdimport.cpp
 
 
 sq32:

--- a/sqstdlib/sqstdimport.cpp
+++ b/sqstdlib/sqstdimport.cpp
@@ -1,0 +1,248 @@
+/* see copyright notice in squirrel.h */
+#include <squirrel.h>
+#include "sqstdmodule.h"
+#include <sqstdimport.h>
+#include <string>
+#if defined(_WIN32)
+#include <windows.h>
+#elif defined(__unix)
+#include <dlfcn.h>
+#endif
+
+typedef SQRESULT (*SQMODULELOAD)(HSQUIRRELVM v, HSQAPI api);
+
+static HSQAPI sqapi = NULL;
+
+static HSQAPI newapi() {
+    HSQAPI sq = (HSQAPI)sq_malloc(sizeof(sq_api));
+
+    /*vm*/
+    sq->open = sq_open;
+    sq->newthread = sq_newthread;
+    sq->seterrorhandler = sq_seterrorhandler;
+    sq->close = sq_close;
+    sq->setforeignptr = sq_setforeignptr;
+    sq->getforeignptr = sq_getforeignptr;
+    sq->setprintfunc = sq_setprintfunc;
+    sq->getprintfunc = sq_getprintfunc;
+    sq->suspendvm = sq_suspendvm;
+    sq->wakeupvm = sq_wakeupvm;
+    sq->getvmstate = sq_getvmstate;
+
+    /*compiler*/
+    sq->compile = sq_compile;
+    sq->compilebuffer = sq_compilebuffer;
+    sq->enabledebuginfo = sq_enabledebuginfo;
+    sq->notifyallexceptions = sq_notifyallexceptions;
+    sq->setcompilererrorhandler = sq_setcompilererrorhandler;
+
+    /*stack operations*/
+    sq->push = sq_push;
+    sq->pop = sq_pop;
+    sq->poptop = sq_poptop;
+    sq->remove = sq_remove;
+    sq->gettop = sq_gettop;
+    sq->settop = sq_settop;
+    sq->reservestack = sq_reservestack;
+    sq->cmp = sq_cmp;
+    sq->move = sq_move;
+
+    /*object creation handling*/
+    sq->newuserdata = sq_newuserdata;
+    sq->newtable = sq_newtable;
+    sq->newarray = sq_newarray;
+    sq->newclosure = sq_newclosure;
+    sq->setparamscheck = sq_setparamscheck;
+    sq->bindenv = sq_bindenv;
+    sq->pushstring = sq_pushstring;
+    sq->pushfloat = sq_pushfloat;
+    sq->pushinteger = sq_pushinteger;
+    sq->pushbool = sq_pushbool;
+    sq->pushuserpointer = sq_pushuserpointer;
+    sq->pushnull = sq_pushnull;
+    sq->gettype = sq_gettype;
+    sq->getsize = sq_getsize;
+    sq->getbase = sq_getbase;
+    sq->instanceof = sq_instanceof;
+    sq->tostring = sq_tostring;
+    sq->tobool = sq_tobool;
+    sq->getstring = sq_getstring;
+    sq->getinteger = sq_getinteger;
+    sq->getthread = sq_getthread;
+    sq->getbool = sq_getbool;
+    sq->getstringandsize = sq_getstringandsize;
+    sq->getuserpointer = sq_getuserpointer;
+    sq->getuserdata = sq_getuserdata;
+    sq->settypetag = sq_settypetag;
+    sq->gettypetag = sq_gettypetag;
+    sq->setreleasehook = sq_setreleasehook;
+    sq->getscratchpad = sq_getscratchpad;
+    sq->getclosureinfo = sq_getclosureinfo;
+    sq->setnativeclosurename = sq_setnativeclosurename;
+    sq->setinstanceup = sq_setinstanceup;
+    sq->getinstanceup = sq_getinstanceup;
+    sq->setclassudsize = sq_setclassudsize;
+    sq->newclass = sq_newclass;
+    sq->createinstance = sq_createinstance;
+    sq->setattributes = sq_setattributes;
+    sq->getattributes = sq_getattributes;
+    sq->getclass = sq_getclass;
+    sq->weakref = sq_weakref;
+    sq->getdefaultdelegate = sq_getdefaultdelegate;
+
+    /*object manipulation*/
+    sq->pushroottable = sq_pushroottable;
+    sq->pushregistrytable = sq_pushregistrytable;
+    sq->pushconsttable = sq_pushconsttable;
+    sq->setroottable = sq_setroottable;
+    sq->setconsttable = sq_setconsttable;
+    sq->newslot = sq_newslot;
+    sq->deleteslot = sq_deleteslot;
+    sq->set = sq_set;
+    sq->get = sq_get;
+    sq->rawset = sq_rawset;
+    sq->rawget = sq_rawget;
+    sq->rawdeleteslot = sq_rawdeleteslot;
+    sq->arrayappend = sq_arrayappend;
+    sq->arraypop = sq_arraypop;
+    sq->arrayresize = sq_arrayresize;
+    sq->arrayreverse = sq_arrayreverse;
+    sq->arrayremove = sq_arrayremove;
+    sq->arrayinsert = sq_arrayinsert;
+    sq->setdelegate = sq_setdelegate;
+    sq->getdelegate = sq_getdelegate;
+    sq->clone = sq_clone;
+    sq->setfreevariable = sq_setfreevariable;
+    sq->next = sq_next;
+    sq->getweakrefval = sq_getweakrefval;
+    sq->clear = sq_clear;
+
+    /*calls*/
+    sq->call = sq_call;
+    sq->resume = sq_resume;
+    sq->getlocal = sq_getlocal;
+    sq->getfreevariable = sq_getfreevariable;
+    sq->throwerror = sq_throwerror;
+    sq->reseterror = sq_reseterror;
+    sq->getlasterror = sq_getlasterror;
+
+    /*raw object handling*/
+    sq->getstackobj = sq_getstackobj;
+    sq->pushobject = sq_pushobject;
+    sq->addref = sq_addref;
+    sq->release = sq_release;
+    sq->resetobject = sq_resetobject;
+    sq->objtostring = sq_objtostring;
+    sq->objtobool = sq_objtobool;
+    sq->objtointeger = sq_objtointeger;
+    sq->objtofloat = sq_objtofloat;
+    sq->getobjtypetag = sq_getobjtypetag;
+
+    /*GC*/
+    sq->collectgarbage = sq_collectgarbage;
+
+    /*serialization*/
+    sq->writeclosure = sq_writeclosure;
+    sq->readclosure = sq_readclosure;
+
+    /*mem allocation*/
+    sq->malloc = sq_malloc;
+    sq->realloc = sq_realloc;
+    sq->free = sq_free;
+
+    /*debug*/
+    sq->stackinfos = sq_stackinfos;
+    sq->setdebughook = sq_setdebughook;
+
+    return sq;
+}
+
+static SQRESULT importbin(HSQUIRRELVM v, const SQChar *modulename) {
+    SQMODULELOAD modload = 0;
+#if defined(_WIN32)
+    HMODULE mod;
+    mod = GetModuleHandle(modulename);
+    if(mod == NULL) {
+        mod = LoadLibrary(modulename);
+        if(mod == NULL) {
+            return SQ_ERROR;
+        }
+    }
+
+    modload = (SQMODULELOAD)GetProcAddress(mod, "sqmodule_load");
+    if(modload == NULL) {
+        FreeLibrary(mod);
+        return SQ_ERROR;
+    }
+#elif defined(__unix)
+    std::basic_string<SQChar> library(modulename);
+    library += _SC(".so");
+    void *mod = dlopen(library.c_str(), RTLD_NOW | RTLD_LOCAL | RTLD_NOLOAD);
+    if(mod == NULL) {
+        mod = dlopen(library.c_str(), RTLD_NOW | RTLD_LOCAL);
+        if(mod == NULL) {
+            return SQ_ERROR;
+        }
+    }
+
+    modload = (SQMODULELOAD)dlsym(mod, "sqmodule_load");
+    if(modload == NULL) {
+        dlclose(mod);
+        return SQ_ERROR;
+    }
+#endif
+    if(sqapi == NULL) {
+        sqapi = newapi();
+    }
+
+    SQRESULT res = modload(v, sqapi);
+    return res;
+}
+
+SQRESULT import(HSQUIRRELVM v) {
+    const SQChar *modulename;
+    HSQOBJECT table;
+    SQRESULT res;
+
+    sq_getstring(v, -2, &modulename);
+    sq_getstackobj(v, -1, &table);
+    sq_addref(v, &table);
+
+    sq_settop(v, 0);
+    sq_pushobject(v, table);
+
+    res = importbin(v, modulename);
+
+    sq_settop(v, 0);
+    sq_pushobject(v, table);
+    sq_release(v, &table);
+
+    return res;
+}
+
+static SQInteger base_import(HSQUIRRELVM v) {
+    SQInteger args = sq_gettop(v);
+    switch(args) {
+    case 2:
+        sq_pushroottable(v);
+        break;
+    case 3:
+        break;
+    default:
+        return SQ_ERROR;
+    }
+
+    import(v);
+    return 1;
+}
+
+SQRESULT sqstd_register_importlib(HSQUIRRELVM v) {
+    sq_pushroottable(v);
+
+    sq_pushstring(v, _SC("import"), -1);
+    sq_newclosure(v, &base_import, 0);
+    sq_newslot(v, -3, SQFalse);
+
+    sq_pop(v, 1);
+    return SQ_OK;
+}

--- a/sqstdlib/sqstdlib.dsp
+++ b/sqstdlib/sqstdlib.dsp
@@ -114,6 +114,10 @@ SOURCE=.\sqstdaux.cpp
 
 SOURCE=.\sqstdsystem.cpp
 # End Source File
+# Begin Source File
+
+SOURCE=.\sqstdimport.cpp
+# End Source File
 # End Group
 # Begin Group "Header Files"
 


### PR DESCRIPTION
Inspired by Sqrat, I feel like this is a very useful functionality to import external libraries to the main Squirrel language. You can use `import(module)` (without the extension) to import the library, and optionally push it to a table.