### PR TITLE
Add support for _SQ64 on 32-bit architectures.

### DIFF
--- a/include/sqconfig.h
+++ b/include/sqconfig.h
@@ -4,14 +4,21 @@
 #ifdef _MSC_VER
 typedef __int64 SQInteger;
 typedef unsigned __int64 SQUnsignedInteger;
+#ifndef _SQ64ON32
 typedef unsigned __int64 SQHash; /*should be the same size of a pointer*/
+#endif
 #else
 typedef long long SQInteger;
 typedef unsigned long long SQUnsignedInteger;
+#ifndef _SQ64ON32
 typedef unsigned long long SQHash; /*should be the same size of a pointer*/
+#endif
 #endif
 typedef int SQInt32;
 typedef unsigned int SQUnsignedInteger32;
+#ifdef _SQ64ON32
+typedef unsigned int SQHash; /*should be the same size of a pointer*/
+#endif
 #else
 typedef int SQInteger;
 typedef int SQInt32; /*must be 32 bits(also on 64bits processors)*/
@@ -20,14 +27,13 @@ typedef unsigned int SQUnsignedInteger;
 typedef unsigned int SQHash; /*should be the same size of a pointer*/
 #endif
 
-
 #ifdef SQUSEDOUBLE
 typedef double SQFloat;
 #else
 typedef float SQFloat;
 #endif
 
-#if defined(SQUSEDOUBLE) && !defined(_SQ64) || !defined(SQUSEDOUBLE) && defined(_SQ64)
+#if defined(SQUSEDOUBLE) && !defined(_SQ64) || !defined(SQUSEDOUBLE) && defined(_SQ64) || defined(_SQ64ON32)
 #ifdef _MSC_VER
 typedef __int64 SQRawObjectVal; //must be 64bits
 #else
@@ -50,6 +56,12 @@ typedef SQUnsignedInteger SQRawObjectVal; //is 32 bits on 32 bits builds and 64 
 typedef void* SQUserPointer;
 typedef SQUnsignedInteger SQBool;
 typedef SQInteger SQRESULT;
+
+#if defined(__cpp_static_assert) && __cpp_static_assert >= 201411L
+static_assert(sizeof(SQUserPointer) == sizeof(SQHash));
+#else
+typedef char _SQ_assert_hash_size[sizeof(SQUserPointer) == sizeof(SQHash) ? 1 : -1];
+#endif
 
 #ifdef SQUNICODE
 #include <wchar.h>

--- a/include/squirrel.h
+++ b/include/squirrel.h
@@ -38,6 +38,10 @@ extern "C" {
 #ifndef _SQ64
 #define _SQ64
 #endif
+#else
+#if (defined(_SQ64) && !defined(_SQ64ON32) && !defined(_NOSQ64ON32))
+#define _SQ64ON32
+#endif
 #endif
 
 

--- a/squirrel/sqobject.cpp
+++ b/squirrel/sqobject.cpp
@@ -92,7 +92,7 @@ SQWeakRef *SQRefCounted::GetWeakRef(SQObjectType type)
 {
     if(!_weakref) {
         sq_new(_weakref,SQWeakRef);
-#if defined(SQUSEDOUBLE) && !defined(_SQ64)
+#if defined(SQUSEDOUBLE) && !defined(_SQ64) || defined(_SQ64ON32)
         _weakref->_obj._unVal.raw = 0; //clean the whole union on 32 bits with double
 #endif
         _weakref->_obj._type = type;

--- a/squirrel/sqobject.h
+++ b/squirrel/sqobject.h
@@ -158,7 +158,7 @@ struct SQObjectPtr;
 #define tointeger(num) ((sq_type(num)==OT_FLOAT)?(SQInteger)_float(num):_integer(num))
 /////////////////////////////////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////////////////////////////////
-#if defined(SQUSEDOUBLE) && !defined(_SQ64) || !defined(SQUSEDOUBLE) && defined(_SQ64)
+#if defined(SQUSEDOUBLE) && !defined(_SQ64) || !defined(SQUSEDOUBLE) && defined(_SQ64) || defined(_SQ64ON32)
 #define SQ_REFOBJECT_INIT() SQ_OBJECT_RAWINIT()
 #else
 #define SQ_REFOBJECT_INIT()


### PR DESCRIPTION
This should be automatically detected so defining `_SQ64` is now safe on 32-bit architectures. If it doesn't auto-detect (because you're using a compiler that doesn't have a `_LP64`-like define) the build will error (using a static assert in compilers that support it and a negative array size in compilers that don't) and you can fix this by defining `_SQ64ON32` or `_NOSQ64ON32` (depending on which direction it misdetected in).

This means that a piece of software that is distributed on both 32 and 64 bit architectures can use a single set of compiled scripts, assuming the size of `SQFloat` and `SQChar` also match.