### PR TITLE
Fix the "`in`" operator acting the same as the "`rawin`" method despite being documented as calling the `_get` metamethod.

### DIFF
--- a/squirrel/sqvm.cpp
+++ b/squirrel/sqvm.cpp
@@ -994,7 +994,7 @@ exception_restore:
 
                         } continue;
             case _OP_CMP:   _GUARD(CMP_OP((CmpOP)arg3,STK(arg2),STK(arg1),TARGET))  continue;
-            case _OP_EXISTS: TARGET = Get(STK(arg1), STK(arg2), temp_reg, GET_FLAG_DO_NOT_RAISE_ERROR | GET_FLAG_RAW, DONT_FALL_BACK) ? true : false; continue;
+            case _OP_EXISTS: TARGET = Get(STK(arg1), STK(arg2), temp_reg, GET_FLAG_DO_NOT_RAISE_ERROR, DONT_FALL_BACK) ? true : false; continue;
             case _OP_INSTANCEOF:
                 if(sq_type(STK(arg1)) != OT_CLASS)
                 {Raise_Error(_SC("cannot apply instanceof between a %s and a %s"),GetTypeName(STK(arg1)),GetTypeName(STK(arg2))); SQ_THROW();}


### PR DESCRIPTION
The documentation for `table.rawin` says:

> returns true if the slot ‘key’ exists. the function has the same effect as the operator ‘in’ but does not employ delegation.

However, `x in y` currently does not employ delegation either. This PR makes it employ delegation.