### PR TITLE
Fix sq_getrefcount adding ref

### DIFF
--- a/squirrel/sqstate.cpp
+++ b/squirrel/sqstate.cpp
@@ -436,8 +436,10 @@ SQUnsignedInteger RefTable::GetRefCount(SQObject &obj)
 {
      SQHash mainpos;
      RefNode *prev;
-     RefNode *ref = Get(obj,mainpos,&prev,true);
-     return ref->refs;
+     RefNode *ref = Get(obj,mainpos,&prev,false);
+     if (ref)
+         return ref->refs;
+     return 0;
 }
 
 


### PR DESCRIPTION
Calling `sq_getrefcount` on an object with no references adds a new reference. This can cause hard to find bugs or memory leaks.

This issue was also quoted to be fixed in the changelog, however none of `sq_getrefcount`, `RefTable::GetRefCount` and `RefTable::Get` were ever changed throughout the [sources available on sourceforge](https://sourceforge.net/projects/squirrel/files/). I'm assuming it got lost due to a mistake.

From the version 3.1 stable changelog:
> -fixed sq_getrefcount() when no references were added with sq_addref() (thx Gerrit)