### PR TITLE
Fix comparison against potentially stale pointer

### DIFF
--- a/squirrel/sqvm.cpp
+++ b/squirrel/sqvm.cpp
@@ -701,7 +701,7 @@ bool SQVM::Execute(SQObjectPtr &closure, SQInteger nargs, SQInteger stackbase,SQ
     _nnativecalls++;
     AutoDec ad(&_nnativecalls);
     SQInteger traps = 0;
-    CallInfo *prevci = ci;
+    SQUnsignedInteger prevci = (SQUnsignedInteger)(ci - _callsstack);
 
     switch(et) {
         case ET_CALL: {
@@ -711,7 +711,7 @@ bool SQVM::Execute(SQObjectPtr &closure, SQInteger nargs, SQInteger stackbase,SQ
                 if(ci == NULL) CallErrorHandler(_lasterror);
                 return false;
             }
-            if(ci == prevci) {
+            if((SQUnsignedInteger)(ci - _callsstack) == prevci) {
                 outres = STK(_top-nargs);
                 return true;
             }


### PR DESCRIPTION
When `SQVM::Execute( ExecutionType: ET_CALL )` is called on a generator function, `StartCall->EnterFrame` increments call frame and `StartCall->Return` decrements it, expecting to pass `if(ci == prevci)` check in `Execute`. However, if the call stack was reallocated in `EnterFrame`, `prevci` would be pointing to the old address. Execution then continues from the call frame that called `SQVM::Execute`. In the case of the example below, a native call frame (`closure_call`) where `ci->ip` is `NULL`, which crashes on dereference.

Fixes #318

```cpp
const SQChar str[] = R"(
	local function f0() { yield; }
	local function f1() { f0.call(null); }
	local function f2() { f1(); }
	f2();
)";
HSQUIRRELVM vm = sq_open( 1024 );
sq_compilebuffer( vm, str, sizeof(str), _SC("sq"), SQTrue );
sq_pushroottable( vm );
SQInteger res = sq_call( vm, 1, SQFalse, SQTrue );
printf("done %d\n", (int)res);
```