### PR TITLE
fix: #292 | EOF and 0-byte infinite loop

### DIFF
--- a/sq/sq.c
+++ b/sq/sq.c
@@ -125,7 +125,7 @@ int getargs(HSQUIRRELVM v,int argc, char* argv[],SQInteger *retval)
                     return _DONE;
                 default:
                     PrintVersionInfos();
-                    scprintf(_SC("unknown prameter '-%c'\n"),argv[arg][1]);
+                    scprintf(_SC("unknown parameter '-%c'\n"),argv[arg][1]);
                     PrintUsage();
                     *retval = -1;
                     return _ERROR;

--- a/sq/sq.c
+++ b/sq/sq.c
@@ -265,6 +265,11 @@ void Interactive(HSQUIRRELVM v)
                     string=!string;
                     buffer[i++] = (SQChar)c;
             }
+            else if (c == _SC('\0') || c == EOF) {
+                scprintf(_SC("\n"));
+                done = SQTrue;
+                break;
+            }
             else if (i >= MAXINPUT-1) {
                 scfprintf(stderr, _SC("sq : input line too long\n"));
                 break;


### PR DESCRIPTION
fix #292 | tldr; "infinite loop in interactive interpreter on EOF and 0-byte"
thanks @Keith-S-Thompson in https://github.com/albertodemichelis/squirrel/issues/292#issuecomment-2547394156 for pointing this out and providing a patch, but `'\0'` should also be checked and doing this last

my tests pass (insignificant lines removed):
- [x] Ctrl-D (^D) , `EOF`
- [x] `'\n'`
- [x] `'\0'`+
- [x] `$ cat /dev/random | squirrel3`...
```
$  ./squirrel3
sq> ^D
$  echo | ./squirrel3
sq>
sq>
$  echo -n | ./squirrel3
sq>
$  cat /dev/null | ./squirrel3
sq>
$  cat /dev/zero | ./squirrel3
sq>
```
note: echoing newline looks correct - 2 prompts

well, `/dev/random` doesn't seem to be correct input ;p , so i haven't checked that thoroughly:
```
$  cat /dev/random | ./squirrel3
sq>
interactive console line = (1) column = (0) : error unexpected character(control)
$  cat /dev/random | ./squirrel3
sq>
interactive console line = (1) column = (1) : error expression expected
```
at least it seem to stop.

let me know if anything more should be checked/tested. this loop still looks like bad to me...